### PR TITLE
[grid.walk] refs #10

### DIFF
--- a/dune/stuff/grid/walk.hh
+++ b/dune/stuff/grid/walk.hh
@@ -67,7 +67,7 @@ public:
   {
     static_assert( codim == 0, "walking intersections is only possible for codim 0 entities" );
     for (const auto& entity : DSC::entityRange(gridView_)) {
-      const int entityIndex = gridView_.indexSet().index(entity);
+      const auto entityIndex = gridView_.indexSet().index(entity);
       entityFunctor( entity, entityIndex);
       for (const auto& intersection : DSC::intersectionRange(gridView_, entity)) {
         intersectionFunctor( entity, intersection);
@@ -83,7 +83,7 @@ public:
   {
     static_assert( codim <= GridViewType::dimension, "codim too high to walk" );
     for (const auto& entity : DSC::entityRange(gridView_)) {
-      const int entityIndex = gridView_.indexSet().index(entity);
+      const auto entityIndex = gridView_.indexSet().index(entity);
       entityFunctor( entity, entityIndex);
     }
   }


### PR DESCRIPTION
This triggers a compilation error in https://github.com/ftalbrecht/dune-stuff/blob/issue-31/dune/stuff/grid/output/pgf.hh#L110. As far as I can tell the reason seems to be that https://github.com/ftalbrecht/dune-stuff/blob/issue-31/dune/stuff/grid/output/pgf.hh#L289 calls this functor in the wrong way, but I am not sure. Perhaps you can investigate this, @renemilk?