### PR TITLE
Add constructor taking a FieldMatrix to Expression function

### DIFF
--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -254,10 +254,9 @@ public:
   template< int rows, int cols >
   Expression(const std::string variable,
              const std::string expression,
-             const size_t ord = default_config().get< size_t >("order"),
-             const std::string nm = static_id(),
-             const Dune::FieldMatrix< std::string, rows, cols > jacobian
-                = Dune::FieldMatrix< std::string, 0, 0 >())
+             const size_t ord,
+             const std::string nm,
+             const Dune::FieldMatrix< std::string, rows, cols > jacobian)
     : function_(new MathExpressionFunctionType(variable, expression))
     , order_(ord)
     , name_(nm)
@@ -268,10 +267,9 @@ public:
   template< int rows, int cols >
   Expression(const std::string variable,
              const std::vector< std::string > expressions,
-             const size_t ord = default_config().get< size_t >("order"),
-             const std::string nm = static_id(),
-             const Dune::FieldMatrix< std::string, rows, cols > jacobian
-                = Dune::FieldMatrix< std::string, 0, 0 >())
+             const size_t ord,
+             const std::string nm,
+             const Dune::FieldMatrix< std::string, rows, cols > jacobian)
     : function_(new MathExpressionFunctionType(variable, expressions))
     , order_(ord)
     , name_(nm)

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -208,14 +208,22 @@ public:
     const Common::Configuration cfg = config.has_sub(sub_name) ? config.sub(sub_name) : config;
     const Common::Configuration default_cfg = default_config();
     // create
-    return Common::make_unique< ThisType >(
-          cfg.get("variable",   default_cfg.get< std::string >("variable")),
-          cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
-          cfg.get("order",      default_cfg.get< size_t >("order")),
-          cfg.get("name",       default_cfg.get< std::string >("name"))
-    );
+    return cfg.has_key("gradient")
+        ? Common::make_unique< ThisType >(
+            cfg.get("variable",   default_cfg.get< std::string >("variable")),
+            cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
+            cfg.get("order",      default_cfg.get< size_t >("order")),
+            cfg.get("name",       default_cfg.get< std::string >("name")),
+            cfg.get< Dune::FieldMatrix< std::string, dimRange, dimDomain > >("gradient"))
+        : Common::make_unique< ThisType >(
+            cfg.get("variable",   default_cfg.get< std::string >("variable")),
+            cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
+            cfg.get("order",      default_cfg.get< size_t >("order")),
+            cfg.get("name",       default_cfg.get< std::string >("name")),
+            Dune::FieldMatrix< std::string, 0, 0 >());
   } // ... create(...)
 
+  // constructors taking a std::vector< std::vector< std::string > > for the jacobian
   Expression(const std::string variable,
              const std::string expression,
              const size_t ord = default_config().get< size_t >("order"),
@@ -240,6 +248,35 @@ public:
     , name_(nm)
   {
     build_gradients(variable, gradient_expressions);
+  }
+
+  // constructors taking a FieldMatrix for the jacobian
+  template< int rows, int cols >
+  Expression(const std::string variable,
+             const std::string expression,
+             const size_t ord = default_config().get< size_t >("order"),
+             const std::string nm = static_id(),
+             const Dune::FieldMatrix< std::string, rows, cols > jacobian
+                = Dune::FieldMatrix< std::string, 0, 0 >())
+    : function_(new MathExpressionFunctionType(variable, expression))
+    , order_(ord)
+    , name_(nm)
+  {
+    build_gradients(variable, jacobian);
+  }
+
+  template< int rows, int cols >
+  Expression(const std::string variable,
+             const std::vector< std::string > expressions,
+             const size_t ord = default_config().get< size_t >("order"),
+             const std::string nm = static_id(),
+             const Dune::FieldMatrix< std::string, rows, cols > jacobian
+                = Dune::FieldMatrix< std::string, 0, 0 >())
+    : function_(new MathExpressionFunctionType(variable, expressions))
+    , order_(ord)
+    , name_(nm)
+  {
+    build_gradients(variable, jacobian);
   }
 
   virtual std::string name() const override
@@ -299,6 +336,21 @@ private:
       for (size_t rr = 0; rr < dimRange; ++rr) {
         const auto& gradient_expression = gradient_expressions[rr];
         assert(gradient_expression.size() >= dimDomain);
+        gradients_.emplace_back(new MathExpressionGradientType(variable, gradient_expression));
+      }
+  } // ... build_gradients(...)
+
+  template< int rows, int cols >
+  void build_gradients(const std::string variable,
+                       Dune::FieldMatrix< std::string, rows, cols > jacobian)
+  {
+    assert(jacobian.rows == 0 || jacobian.rows >= dimRange);
+    assert(jacobian.cols == 0 || jacobian.cols >= dimDomain);
+    if (jacobian.rows > 0 && jacobian.cols > 0)
+      for (size_t rr = 0; rr < dimRange; ++rr) {
+        std::vector< std::string > gradient_expression;
+        for (size_t cc = 0; cc < dimDomain; ++cc)
+          gradient_expression.emplace_back(jacobian[rr][cc]);
         gradients_.emplace_back(new MathExpressionGradientType(variable, gradient_expression));
       }
   } // ... build_gradients(...)

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -214,8 +214,6 @@ public:
       typedef typename Dune::FieldMatrix< std::string, dimRange, dimDomain > JacobianMatrixType;
       const JacobianMatrixType gradient_as_matrix = cfg.get< JacobianMatrixType >("gradient");
       // convert FieldMatrix to std::vector< std::vector < std::string > >
-      assert(gradient_as_matrix.rows >= dimRange);
-      assert(gradient_as_matrix.cols >= dimDomain);
       for (size_t rr = 0; rr < dimRange; ++rr) {
         std::vector< std::string > gradient_expression;
         for (size_t cc = 0; cc < dimDomain; ++cc)

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -207,23 +207,31 @@ public:
     // get correct config
     const Common::Configuration cfg = config.has_sub(sub_name) ? config.sub(sub_name) : config;
     const Common::Configuration default_cfg = default_config();
+    // get gradient
+    std::vector< std::vector < std::string > > gradient_as_vectors;
+    if (cfg.has_key("gradient")) {
+      // get gradient as FieldMatrix
+      typedef typename Dune::FieldMatrix< std::string, dimRange, dimDomain > JacobianMatrixType;
+      const JacobianMatrixType gradient_as_matrix = cfg.get< JacobianMatrixType >("gradient");
+      // convert FieldMatrix to std::vector< std::vector < std::string > >
+      assert(gradient_as_matrix.rows >= dimRange);
+      assert(gradient_as_matrix.cols >= dimDomain);
+      for (size_t rr = 0; rr < dimRange; ++rr) {
+        std::vector< std::string > gradient_expression;
+        for (size_t cc = 0; cc < dimDomain; ++cc)
+          gradient_expression.emplace_back(gradient_as_matrix[rr][cc]);
+        gradient_as_vectors.emplace_back(gradient_expression);
+      }
+    }
     // create
-    return cfg.has_key("gradient")
-        ? Common::make_unique< ThisType >(
-            cfg.get("variable",   default_cfg.get< std::string >("variable")),
-            cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
-            cfg.get("order",      default_cfg.get< size_t >("order")),
-            cfg.get("name",       default_cfg.get< std::string >("name")),
-            cfg.get< Dune::FieldMatrix< std::string, dimRange, dimDomain > >("gradient"))
-        : Common::make_unique< ThisType >(
-            cfg.get("variable",   default_cfg.get< std::string >("variable")),
-            cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
-            cfg.get("order",      default_cfg.get< size_t >("order")),
-            cfg.get("name",       default_cfg.get< std::string >("name")),
-            Dune::FieldMatrix< std::string, 0, 0 >());
+    return Common::make_unique< ThisType >(
+          cfg.get("variable",   default_cfg.get< std::string >("variable")),
+          cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
+          cfg.get("order",      default_cfg.get< size_t >("order")),
+          cfg.get("name",       default_cfg.get< std::string >("name")),
+          gradient_as_vectors);
   } // ... create(...)
 
-  // constructors taking a std::vector< std::vector< std::string > > for the jacobian
   Expression(const std::string variable,
              const std::string expression,
              const size_t ord = default_config().get< size_t >("order"),
@@ -248,33 +256,6 @@ public:
     , name_(nm)
   {
     build_gradients(variable, gradient_expressions);
-  }
-
-  // constructors taking a FieldMatrix for the jacobian
-  template< int rows, int cols >
-  Expression(const std::string variable,
-             const std::string expression,
-             const size_t ord,
-             const std::string nm,
-             const Dune::FieldMatrix< std::string, rows, cols > jacobian)
-    : function_(new MathExpressionFunctionType(variable, expression))
-    , order_(ord)
-    , name_(nm)
-  {
-    build_gradients(variable, jacobian);
-  }
-
-  template< int rows, int cols >
-  Expression(const std::string variable,
-             const std::vector< std::string > expressions,
-             const size_t ord,
-             const std::string nm,
-             const Dune::FieldMatrix< std::string, rows, cols > jacobian)
-    : function_(new MathExpressionFunctionType(variable, expressions))
-    , order_(ord)
-    , name_(nm)
-  {
-    build_gradients(variable, jacobian);
   }
 
   virtual std::string name() const override
@@ -314,7 +295,7 @@ public:
                  << "You can disable this check by defining DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS\n");
 # endif // DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS
 #endif // NDEBUG
-  }
+  } // ... evaluate(...)
 
   virtual void jacobian(const DomainType& xx, JacobianRangeType& ret) const override
   {
@@ -325,6 +306,7 @@ public:
       gradients_[ii]->evaluate(xx, ret[ii]);
     }
   } // ... jacobian(...)
+
 private:
   void build_gradients(const std::string variable,
                        const std::vector< std::vector< std::string > >& gradient_expressions)
@@ -334,21 +316,6 @@ private:
       for (size_t rr = 0; rr < dimRange; ++rr) {
         const auto& gradient_expression = gradient_expressions[rr];
         assert(gradient_expression.size() >= dimDomain);
-        gradients_.emplace_back(new MathExpressionGradientType(variable, gradient_expression));
-      }
-  } // ... build_gradients(...)
-
-  template< int rows, int cols >
-  void build_gradients(const std::string variable,
-                       Dune::FieldMatrix< std::string, rows, cols > jacobian)
-  {
-    assert(jacobian.rows == 0 || jacobian.rows >= dimRange);
-    assert(jacobian.cols == 0 || jacobian.cols >= dimDomain);
-    if (jacobian.rows > 0 && jacobian.cols > 0)
-      for (size_t rr = 0; rr < dimRange; ++rr) {
-        std::vector< std::string > gradient_expression;
-        for (size_t cc = 0; cc < dimDomain; ++cc)
-          gradient_expression.emplace_back(jacobian[rr][cc]);
         gradients_.emplace_back(new MathExpressionGradientType(variable, gradient_expression));
       }
   } // ... build_gradients(...)

--- a/dune/stuff/test/functions_expression.cc
+++ b/dune/stuff/test/functions_expression.cc
@@ -34,13 +34,10 @@
     void check() const \
     { \
       Dune::Stuff::Common::Configuration config = LocalizableFunctionType::default_config(); \
-      const std::unique_ptr< const LocalizableFunctionType > \
-          function(LocalizableFunctionType::create(config)); \
+      const std::unique_ptr< const LocalizableFunctionType > function(LocalizableFunctionType::create(config)); \
       config["expression"] = "[2*x[0] 2*x[1] 2*x[2]]"; \
       config["gradient"] = "[2 0 0; 0 2 0; 0 0 2]"; \
-      const std::unique_ptr< const LocalizableFunctionType > \
-          function2(LocalizableFunctionType::create(config)); \
-      const LocalizableFunctionType function3("x", {"x[0]", "x[0]", "x[0]"}); \
+      const std::unique_ptr< const LocalizableFunctionType > function2(LocalizableFunctionType::create(config)); \
     } \
   };
 // TEST_STRUCT_GENERATOR

--- a/dune/stuff/test/functions_expression.cc
+++ b/dune/stuff/test/functions_expression.cc
@@ -33,8 +33,14 @@
  \
     void check() const \
     { \
+      Dune::Stuff::Common::Configuration config = LocalizableFunctionType::default_config(); \
       const std::unique_ptr< const LocalizableFunctionType > \
-          function(LocalizableFunctionType::create(LocalizableFunctionType::default_config())); \
+          function(LocalizableFunctionType::create(config)); \
+      config["expression"] = "[2*x[0] 2*x[1] 2*x[2]]"; \
+      config["gradient"] = "[2 0 0; 0 2 0; 0 0 2]"; \
+      const std::unique_ptr< const LocalizableFunctionType > \
+          function2(LocalizableFunctionType::create(config)); \
+      const LocalizableFunctionType function3("x", {"x[0]", "x[0]", "x[0]"}); \
     } \
   };
 // TEST_STRUCT_GENERATOR


### PR DESCRIPTION
Adds constructors and build_gradient methods taking a FieldMatrix instead of a std::vector< std::vector < ... > >. This makes it easier to use the create() method to create an Expression function with non-empty gradient.
I will add a few tests to test/functions_expression.cc.