### PR TITLE
Enable complex-valued matrices and vectors 

### DIFF
--- a/dune/stuff/common/float_cmp.hh
+++ b/dune/stuff/common/float_cmp.hh
@@ -7,6 +7,7 @@
 #define DUNE_STUFF_COMMON_FLOAT_CMP_HH
 
 #include <type_traits>
+#include <complex>
 
 #include <dune/common/float_cmp.hh>
 
@@ -101,8 +102,8 @@ template< class XType, class YType, class TolType >
     typename std::enable_if<    is_vector< XType >::value
                              && is_vector< YType >::value
                              && std::is_arithmetic< TolType >::value
-                             && std::is_same< typename VectorAbstraction< XType >::S, TolType >::value
-                             && std::is_same< typename VectorAbstraction< YType >::S, TolType >::value
+                             && std::is_same< typename VectorAbstraction< XType >::R, TolType >::value
+                             && std::is_same< typename VectorAbstraction< YType >::R, TolType >::value
                            , bool >::type
 float_cmp(const XType& xx, const YType& yy, const TolType& rtol, const TolType& atol)
 {
@@ -110,7 +111,7 @@ float_cmp(const XType& xx, const YType& yy, const TolType& rtol, const TolType& 
   if (yy.size() != sz)
     return false;
   for (size_t ii = 0; ii < sz; ++ii)
-    if (!float_cmp(xx[ii], yy[ii], rtol, atol))
+    if (!float_cmp(std::real(xx[ii]), std::real(yy[ii]), rtol, atol) || !float_cmp(std::imag(xx[ii]), std::imag(yy[ii]), rtol, atol))
       return false;
   return true;
 } // ... float_cmp(...)
@@ -127,8 +128,8 @@ template< Dune::FloatCmp::CmpStyle style, class XType, class YType, class EpsTyp
 typename std::enable_if<    is_vector< XType >::value
                          && is_vector< YType >::value
                          && std::is_arithmetic< EpsType >::value
-                         && std::is_same< typename VectorAbstraction< XType >::S, EpsType >::value
-                         && std::is_same< typename VectorAbstraction< YType >::S, EpsType >::value
+                         && std::is_same< typename VectorAbstraction< XType >::R, EpsType >::value
+                         && std::is_same< typename VectorAbstraction< YType >::R, EpsType >::value
                        , bool >::type
 dune_float_cmp(const XType& xx, const YType& yy, const EpsType& eps)
 {
@@ -265,16 +266,16 @@ struct Call< FirstType, SecondType, ToleranceType, Style::numpy >
 
 
 #define DUNE_STUFF_COMMON_FLOAT_CMP_GENERATOR(id) \
-  template< Style style, class FirstType, class SecondType, class ToleranceType = typename VectorAbstraction< FirstType >::S > \
+  template< Style style, class FirstType, class SecondType, class ToleranceType = typename VectorAbstraction< FirstType >::R > \
       typename std::enable_if<    (   std::is_arithmetic< FirstType >::value \
                                    && std::is_same< FirstType, SecondType >::value) \
                                || (std::is_arithmetic< ToleranceType >::value \
                                    && is_vector< FirstType >::value \
                                    && is_vector< SecondType >::value \
                                    && std::is_same< ToleranceType \
-                                                  , typename VectorAbstraction< FirstType >::S >::value \
+                                                  , typename VectorAbstraction< FirstType >::R >::value \
                                    && std::is_same< ToleranceType \
-                                                  , typename VectorAbstraction< SecondType >::S >::value) \
+                                                  , typename VectorAbstraction< SecondType >::R >::value) \
                              , bool >::type \
   id (const FirstType& first, \
       const SecondType& second, \
@@ -289,16 +290,16 @@ struct Call< FirstType, SecondType, ToleranceType, Style::numpy >
                            style >:: id (first, second, rtol, atol); \
   } \
   \
-  template< class FirstType, class SecondType, class ToleranceType = typename VectorAbstraction< FirstType >::S > \
+  template< class FirstType, class SecondType, class ToleranceType = typename VectorAbstraction< FirstType >::R > \
       typename std::enable_if<    (   std::is_arithmetic< FirstType >::value \
                                    && std::is_same< FirstType, SecondType >::value) \
                                || (std::is_arithmetic< ToleranceType >::value \
                                    && is_vector< FirstType >::value \
                                    && is_vector< SecondType >::value \
                                    && std::is_same< ToleranceType \
-                                                  , typename VectorAbstraction< FirstType >::S >::value \
+                                                  , typename VectorAbstraction< FirstType >::R >::value \
                                    && std::is_same< ToleranceType \
-                                                  , typename VectorAbstraction< SecondType >::S >::value) \
+                                                  , typename VectorAbstraction< SecondType >::R >::value) \
                              , bool >::type \
   id (const FirstType& first, \
       const SecondType& second, \

--- a/dune/stuff/common/float_cmp.hh
+++ b/dune/stuff/common/float_cmp.hh
@@ -15,6 +15,31 @@ namespace Dune {
 namespace Stuff {
 namespace Common {
 
+namespace internal {
+
+
+template< class Tt >
+struct is_complex_helper
+{
+  DSC_has_typedef_initialize_once(value_type)
+
+  static const bool is_candidate = DSC_has_typedef(value_type)< Tt >::value;
+}; // class is_complex_helper
+
+
+} // namespace internal
+
+
+template< class T, bool candidate = internal::is_complex_helper< T >::is_candidate >
+struct is_complex
+  : public std::is_base_of< std::complex< typename T::value_type >, T >
+{};
+
+
+template< class T >
+struct is_complex< T, false >
+  : public std::false_type
+{};
 
 // forwards (include is below)
 template< class VecType >
@@ -98,6 +123,14 @@ float_cmp(const T& xx, const T& yy, const T& rtol, const T& atol)
 }
 
 
+template< class T >
+    typename std::enable_if< is_complex< T >::value, bool >::type
+float_cmp(const T& xx, const T& yy, const typename T::value_type& rtol, const typename T::value_type& atol )
+{
+  return (float_cmp(std::real(xx), std::real(yy), rtol, atol) && float_cmp(std::imag(xx), std::imag(yy), rtol, atol));
+}
+
+
 template< class XType, class YType, class TolType >
     typename std::enable_if<    is_vector< XType >::value
                              && is_vector< YType >::value
@@ -111,7 +144,7 @@ float_cmp(const XType& xx, const YType& yy, const TolType& rtol, const TolType& 
   if (yy.size() != sz)
     return false;
   for (size_t ii = 0; ii < sz; ++ii)
-    if (!float_cmp(std::real(xx[ii]), std::real(yy[ii]), rtol, atol) || !float_cmp(std::imag(xx[ii]), std::imag(yy[ii]), rtol, atol))
+    if (!float_cmp(xx[ii], yy[ii], rtol, atol))
       return false;
   return true;
 } // ... float_cmp(...)

--- a/dune/stuff/common/float_cmp.hh
+++ b/dune/stuff/common/float_cmp.hh
@@ -161,8 +161,8 @@ template< Dune::FloatCmp::CmpStyle style, class XType, class YType, class EpsTyp
 typename std::enable_if<    is_vector< XType >::value
                          && is_vector< YType >::value
                          && std::is_arithmetic< EpsType >::value
-                         && std::is_same< typename VectorAbstraction< XType >::R, EpsType >::value
-                         && std::is_same< typename VectorAbstraction< YType >::R, EpsType >::value
+                         && std::is_same< typename VectorAbstraction< XType >::S, EpsType >::value
+                         && std::is_same< typename VectorAbstraction< YType >::S, EpsType >::value
                        , bool >::type
 dune_float_cmp(const XType& xx, const YType& yy, const EpsType& eps)
 {

--- a/dune/stuff/common/vector.hh
+++ b/dune/stuff/common/vector.hh
@@ -36,6 +36,7 @@ struct VectorAbstraction
 {
   typedef VecType VectorType;
   typedef VecType ScalarType;
+  typedef VecType RealType;
   typedef VecType S;
   typedef VecType R;
 
@@ -59,12 +60,11 @@ struct VectorAbstraction
 template< class T >
 struct VectorAbstraction< std::vector< T > >
 {
-  typedef std::vector< T > VectorType;
-  //typedef typename Dune::FieldTraits< T >::field_type ScalarType;
-  typedef T ScalarType;
-  typedef ScalarType       S;
-  //typedef typename Dune::FieldTraits< T >::real_type RealScalarType;
-  //typedef typename RealScalarType R;
+  typedef std::vector< T >                            VectorType;
+  typedef typename Dune::FieldTraits< T >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< T >::real_type  RealType;
+  typedef ScalarType S;
+  typedef RealType   R;
 
   static const bool is_vector = true;
 
@@ -86,11 +86,11 @@ struct VectorAbstraction< std::vector< T > >
 template< class K >
 struct VectorAbstraction< Dune::DynamicVector< K > >
 {
-  typedef Dune::DynamicVector< K > VectorType;
+  typedef Dune::DynamicVector< K >                    VectorType;
   typedef typename Dune::FieldTraits< K >::field_type ScalarType;
-  typedef ScalarType               S;
-  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
-  typedef RealScalarType R;
+  typedef typename Dune::FieldTraits< K >::real_type  RealType;
+  typedef ScalarType S;
+  typedef RealType   R;
 
   static const bool is_vector = true;
 
@@ -112,11 +112,11 @@ struct VectorAbstraction< Dune::DynamicVector< K > >
 template< class K, int SIZE >
 struct VectorAbstraction< Dune::FieldVector< K, SIZE > >
 {
-  typedef Dune::FieldVector< K, SIZE > VectorType;
+  typedef Dune::FieldVector< K, SIZE >                VectorType;
   typedef typename Dune::FieldTraits< K >::field_type ScalarType;
-  typedef ScalarType                   S;
-  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
-  typedef RealScalarType R;
+  typedef typename Dune::FieldTraits< K >::real_type  RealType;
+  typedef ScalarType S;
+  typedef RealType   R;
 
   static const bool is_vector = true;
 
@@ -144,11 +144,11 @@ struct VectorAbstraction< Dune::FieldVector< K, SIZE > >
 template< class K, int SIZE >
 struct VectorAbstraction< Dune::Stuff::Common::FieldVector< K, SIZE > >
 {
-  typedef Dune::Stuff::Common::FieldVector< K, SIZE > VectorType;
-  typedef typename Dune::FieldTraits< K >::field_type ScalarType;
-  typedef ScalarType                                  S;
-  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
-  typedef RealScalarType R;
+  typedef Dune::Stuff::Common::FieldVector< K, SIZE >  VectorType;
+  typedef typename Dune::FieldTraits< K >::field_type  ScalarType;
+    typedef typename Dune::FieldTraits< K >::real_type RealType;
+  typedef ScalarType S;
+  typedef RealType   R;
 
   static const bool is_vector = true;
 

--- a/dune/stuff/common/vector.hh
+++ b/dune/stuff/common/vector.hh
@@ -146,7 +146,7 @@ struct VectorAbstraction< Dune::Stuff::Common::FieldVector< K, SIZE > >
 {
   typedef Dune::Stuff::Common::FieldVector< K, SIZE >  VectorType;
   typedef typename Dune::FieldTraits< K >::field_type  ScalarType;
-    typedef typename Dune::FieldTraits< K >::real_type RealType;
+  typedef typename Dune::FieldTraits< K >::real_type RealType;
   typedef ScalarType S;
   typedef RealType   R;
 

--- a/dune/stuff/common/vector.hh
+++ b/dune/stuff/common/vector.hh
@@ -11,6 +11,7 @@
 
 #include <dune/common/dynvector.hh>
 #include <dune/common/fvector.hh>
+#include <dune/common/ftraits.hh>
 
 #include <dune/stuff/common/exceptions.hh>
 #include <dune/stuff/common/float_cmp.hh>
@@ -36,6 +37,7 @@ struct VectorAbstraction
   typedef VecType VectorType;
   typedef VecType ScalarType;
   typedef VecType S;
+  typedef VecType R;
 
   static const bool is_vector = false;
 
@@ -58,8 +60,11 @@ template< class T >
 struct VectorAbstraction< std::vector< T > >
 {
   typedef std::vector< T > VectorType;
-  typedef T                ScalarType;
+  //typedef typename Dune::FieldTraits< T >::field_type ScalarType;
+  typedef T ScalarType;
   typedef ScalarType       S;
+  //typedef typename Dune::FieldTraits< T >::real_type RealScalarType;
+  //typedef typename RealScalarType R;
 
   static const bool is_vector = true;
 
@@ -82,8 +87,10 @@ template< class K >
 struct VectorAbstraction< Dune::DynamicVector< K > >
 {
   typedef Dune::DynamicVector< K > VectorType;
-  typedef K                        ScalarType;
+  typedef typename Dune::FieldTraits< K >::field_type ScalarType;
   typedef ScalarType               S;
+  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
+  typedef RealScalarType R;
 
   static const bool is_vector = true;
 
@@ -106,8 +113,10 @@ template< class K, int SIZE >
 struct VectorAbstraction< Dune::FieldVector< K, SIZE > >
 {
   typedef Dune::FieldVector< K, SIZE > VectorType;
-  typedef K                            ScalarType;
+  typedef typename Dune::FieldTraits< K >::field_type ScalarType;
   typedef ScalarType                   S;
+  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
+  typedef RealScalarType R;
 
   static const bool is_vector = true;
 
@@ -136,8 +145,10 @@ template< class K, int SIZE >
 struct VectorAbstraction< Dune::Stuff::Common::FieldVector< K, SIZE > >
 {
   typedef Dune::Stuff::Common::FieldVector< K, SIZE > VectorType;
-  typedef K                                           ScalarType;
+  typedef typename Dune::FieldTraits< K >::field_type ScalarType;
   typedef ScalarType                                  S;
+  typedef typename Dune::FieldTraits< K >::real_type RealScalarType;
+  typedef RealScalarType R;
 
   static const bool is_vector = true;
 

--- a/dune/stuff/la/container/common.hh
+++ b/dune/stuff/la/container/common.hh
@@ -47,7 +47,8 @@ template< class ScalarImp = double >
 class CommonDenseVectorTraits
 {
 public:
-  typedef ScalarImp                         ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef CommonDenseVector< ScalarType >   derived_type;
   typedef Dune::DynamicVector< ScalarType > BackendType;
 };
@@ -82,6 +83,7 @@ class CommonDenseVector
 public:
   typedef internal::CommonDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                    ScalarType;
+  typedef typename Traits::RealScalarType                RealScalarType;
   typedef typename Traits::BackendType                   BackendType;
 
   explicit CommonDenseVector(const size_t ss = 0, const ScalarType value = ScalarType(0))
@@ -253,17 +255,17 @@ public:
     return backend_->operator*(*(other.backend_));
   } // ... dot(...)
 
-  virtual ScalarType l1_norm() const override final
+  virtual RealScalarType l1_norm() const override final
   {
     return backend_->one_norm();
   }
 
-  virtual ScalarType l2_norm() const override final
+  virtual RealScalarType l2_norm() const override final
   {
     return backend_->two_norm();
   }
 
-  virtual ScalarType sup_norm() const override final
+  virtual RealScalarType sup_norm() const override final
   {
     return backend_->infinity_norm();
   }

--- a/dune/stuff/la/container/common.hh
+++ b/dune/stuff/la/container/common.hh
@@ -48,9 +48,9 @@ class CommonDenseVectorTraits
 {
 public:
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef CommonDenseVector< ScalarType >   derived_type;
-  typedef Dune::DynamicVector< ScalarType > BackendType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
+  typedef CommonDenseVector< ScalarType >                     derived_type;
+  typedef Dune::DynamicVector< ScalarType >                   BackendType;
 };
 
 
@@ -59,9 +59,9 @@ class CommonDenseMatrixTraits
 {
 public:
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef CommonDenseMatrix< ScalarType >   derived_type;
-  typedef Dune::DynamicMatrix< ScalarType > BackendType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
+  typedef CommonDenseMatrix< ScalarType >                     derived_type;
+  typedef Dune::DynamicMatrix< ScalarType >                   BackendType;
 };
 
 
@@ -83,7 +83,7 @@ class CommonDenseVector
 public:
   typedef internal::CommonDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                    ScalarType;
-  typedef typename Traits::RealScalarType                RealScalarType;
+  typedef typename Traits::RealType                      RealType;
   typedef typename Traits::BackendType                   BackendType;
 
   explicit CommonDenseVector(const size_t ss = 0, const ScalarType value = ScalarType(0))
@@ -255,17 +255,17 @@ public:
     return backend_->operator*(*(other.backend_));
   } // ... dot(...)
 
-  virtual RealScalarType l1_norm() const override final
+  virtual RealType l1_norm() const override final
   {
     return backend_->one_norm();
   }
 
-  virtual RealScalarType l2_norm() const override final
+  virtual RealType l2_norm() const override final
   {
     return backend_->two_norm();
   }
 
-  virtual RealScalarType sup_norm() const override final
+  virtual RealType sup_norm() const override final
   {
     return backend_->infinity_norm();
   }
@@ -354,7 +354,7 @@ public:
   typedef internal::CommonDenseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                   BackendType;
   typedef typename Traits::ScalarType                    ScalarType;
-  typedef typename Traits::RealScalarType                RealScalarType;
+  typedef typename Traits::RealType                      RealType;
 
   explicit CommonDenseMatrix(const size_t rr = 0, const size_t cc = 0, const ScalarType value = ScalarType(0))
     : backend_(new BackendType(rr, cc, value))

--- a/dune/stuff/la/container/common.hh
+++ b/dune/stuff/la/container/common.hh
@@ -13,6 +13,7 @@
 #include <memory>
 #include <type_traits>
 #include <vector>
+#include <complex>
 
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -20,6 +21,7 @@
 #include <dune/common/dynmatrix.hh>
 #include <dune/common/densematrix.hh>
 #include <dune/common/float_cmp.hh>
+#include <dune/common/ftraits.hh>
 
 #include "interfaces.hh"
 #include "pattern.hh"
@@ -55,7 +57,8 @@ template< class ScalarImp = double >
 class CommonDenseMatrixTraits
 {
 public:
-  typedef ScalarImp                         ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef CommonDenseMatrix< ScalarType >   derived_type;
   typedef Dune::DynamicMatrix< ScalarType > BackendType;
 };
@@ -349,6 +352,7 @@ public:
   typedef internal::CommonDenseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                   BackendType;
   typedef typename Traits::ScalarType                    ScalarType;
+  typedef typename Traits::RealScalarType                RealScalarType;
 
   explicit CommonDenseMatrix(const size_t rr = 0, const size_t cc = 0, const ScalarType value = ScalarType(0))
     : backend_(new BackendType(rr, cc, value))
@@ -556,7 +560,7 @@ public:
       const auto& row_vec = backend_->operator[](ii);
       for (size_t jj = 0; jj < cols(); ++jj) {
         const auto& entry = row_vec[jj];
-        if (std::isnan(entry) || std::isinf(entry))
+        if (std::isnan(std::real(entry)) || std::isnan(std::imag(entry)) || std::isinf(std::abs(entry)))
           return false;
       }
     }

--- a/dune/stuff/la/container/eigen/base.hh
+++ b/dune/stuff/la/container/eigen/base.hh
@@ -59,7 +59,7 @@ class EigenBaseVector
 public:
   typedef ImpTraits Traits;
   typedef typename Traits::ScalarType   ScalarType;
-  typedef typename Traits::RealScalarType RealScalarType;
+  typedef typename Traits::RealType     RealType;
   typedef typename Traits::BackendType  BackendType;
   typedef typename Traits::derived_type VectorImpType;
 
@@ -165,13 +165,13 @@ public:
   /// \name These methods override default implementations from VectorInterface.
   /// \{
 
-  virtual std::pair< size_t, RealScalarType > amax() const override final
+  virtual std::pair< size_t, RealType > amax() const override final
   {
-    auto result = std::make_pair(size_t(0), RealScalarType(0));
+    auto result = std::make_pair(size_t(0), RealType(0));
     size_t min_index = 0;
     size_t max_index = 0;
-    const RealScalarType minimum = (backend_->cwiseAbs()).minCoeff(&min_index);
-    const RealScalarType maximum = (backend_->cwiseAbs()).maxCoeff(&max_index);
+    const RealType minimum = (backend_->cwiseAbs()).minCoeff(&min_index);
+    const RealType maximum = (backend_->cwiseAbs()).maxCoeff(&max_index);
     if (maximum < minimum
         || (Common::FloatCmp::eq(maximum, minimum) && max_index > min_index)) {
       result.first = min_index;
@@ -197,17 +197,17 @@ public:
     return this->template dot< Traits >(other);
   }
 
-  virtual RealScalarType l1_norm() const override final
+  virtual RealType l1_norm() const override final
   {
     return backend_->template lpNorm< 1 >();
   }
 
-  virtual RealScalarType l2_norm() const override final
+  virtual RealType l2_norm() const override final
   {
     return backend_->template lpNorm< 2 >();
   }
 
-  virtual RealScalarType sup_norm() const override final
+  virtual RealType sup_norm() const override final
   {
     return backend_->template lpNorm< ::Eigen::Infinity >();
   }

--- a/dune/stuff/la/container/eigen/base.hh
+++ b/dune/stuff/la/container/eigen/base.hh
@@ -9,6 +9,7 @@
 #include <memory>
 #include <type_traits>
 #include <vector>
+#include <complex>
 
 #include <dune/stuff/common/disable_warnings.hh>
 # if HAVE_EIGEN
@@ -17,6 +18,7 @@
 #include <dune/stuff/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
+#include <dune/common/ftraits.hh>
 
 #include <dune/stuff/aliases.hh>
 #include <dune/stuff/common/exceptions.hh>
@@ -57,6 +59,7 @@ class EigenBaseVector
 public:
   typedef ImpTraits Traits;
   typedef typename Traits::ScalarType   ScalarType;
+  typedef typename Traits::RealScalarType RealScalarType;
   typedef typename Traits::BackendType  BackendType;
   typedef typename Traits::derived_type VectorImpType;
 
@@ -162,20 +165,20 @@ public:
   /// \name These methods override default implementations from VectorInterface.
   /// \{
 
-  virtual std::pair< size_t, ScalarType > amax() const override final
+  virtual std::pair< size_t, RealScalarType > amax() const override final
   {
-    auto result = std::make_pair(size_t(0), ScalarType(0));
+    auto result = std::make_pair(size_t(0), RealScalarType(0));
     size_t min_index = 0;
     size_t max_index = 0;
-    const ScalarType minimum = backend_->minCoeff(&min_index);
-    const ScalarType maximum = backend_->maxCoeff(&max_index);
-    if (std::abs(maximum) < std::abs(minimum)
-        || (Common::FloatCmp::eq(std::abs(maximum), std::abs(minimum)) && max_index > min_index)) {
+    const RealScalarType minimum = (backend_->cwiseAbs()).minCoeff(&min_index);
+    const RealScalarType maximum = (backend_->cwiseAbs()).maxCoeff(&max_index);
+    if (maximum < minimum
+        || (Common::FloatCmp::eq(maximum, minimum) && max_index > min_index)) {
       result.first = min_index;
-      result.second = std::abs(minimum);
+      result.second = minimum;
     } else {
       result.first = max_index;
-      result.second = std::abs(maximum);
+      result.second = maximum;
     }
     return result;
   } // ... amax(...)
@@ -194,17 +197,17 @@ public:
     return this->template dot< Traits >(other);
   }
 
-  virtual ScalarType l1_norm() const override final
+  virtual RealScalarType l1_norm() const override final
   {
     return backend_->template lpNorm< 1 >();
   }
 
-  virtual ScalarType l2_norm() const override final
+  virtual RealScalarType l2_norm() const override final
   {
     return backend_->template lpNorm< 2 >();
   }
 
-  virtual ScalarType sup_norm() const override final
+  virtual RealScalarType sup_norm() const override final
   {
     return backend_->template lpNorm< ::Eigen::Infinity >();
   }

--- a/dune/stuff/la/container/eigen/dense.hh
+++ b/dune/stuff/la/container/eigen/dense.hh
@@ -62,9 +62,9 @@ template< class ScalarImp = double >
 class EigenDenseVectorTraits
 {
 public:
-  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef EigenDenseVector< ScalarType > derived_type;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type         ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type          RealType;
+  typedef EigenDenseVector< ScalarType >                              derived_type;
   typedef typename ::Eigen::Matrix< ScalarType, ::Eigen::Dynamic, 1 > BackendType;
 }; // class EigenDenseVectorTraits
 
@@ -78,9 +78,9 @@ class EigenMappedDenseVectorTraits
   typedef typename ::Eigen::Matrix< ScalarImp, ::Eigen::Dynamic, 1 > PlainBackendType;
 public:
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef EigenMappedDenseVector< ScalarType > derived_type;
-  typedef Eigen::Map< PlainBackendType >       BackendType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
+  typedef EigenMappedDenseVector< ScalarType >                derived_type;
+  typedef Eigen::Map< PlainBackendType >                      BackendType;
 }; // class EigenMappedDenseVectorTraits
 
 
@@ -91,9 +91,9 @@ template< class ScalarImp = double >
 class EigenDenseMatrixTraits
 {
 public:
-  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef EigenDenseMatrix< ScalarType > derived_type;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type                        ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type                         RealType;
+  typedef EigenDenseMatrix< ScalarType >                                             derived_type;
   typedef typename ::Eigen::Matrix< ScalarType, ::Eigen::Dynamic, ::Eigen::Dynamic > BackendType;
 }; // class EigenDenseMatrixTraits
 
@@ -111,13 +111,13 @@ class EigenDenseVector
 {
   typedef EigenDenseVector< ScalarImp >                                               ThisType;
   typedef VectorInterface< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp > VectorInterfaceType;
-  typedef EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp >            BaseType;
+  typedef EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp > BaseType;
   static_assert(!std::is_same< DUNE_STUFF_SSIZE_T, int >::value,
                 "You have to manually disable the constructor below which uses DUNE_STUFF_SSIZE_T!");
 public:
   typedef internal::EigenDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                   ScalarType;
-  typedef typename Traits::RealScalarType               RealScalarType;
+  typedef typename Traits::RealType                     RealType;
   typedef typename Traits::BackendType                  BackendType;
 
 private:
@@ -216,7 +216,7 @@ class EigenMappedDenseVector
 {
   typedef EigenMappedDenseVector< ScalarImp >                                               ThisType;
   typedef VectorInterface< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp > VectorInterfaceType;
-  typedef EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp >            BaseType;
+  typedef EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp > BaseType;
   static_assert(std::is_same< ScalarImp, double >::value, "Undefined behaviour for non-double data!");
   static_assert(!std::is_same< DUNE_STUFF_SSIZE_T, int >::value,
                 "You have to manually disable the constructor below which uses DUNE_STUFF_SSIZE_T!");
@@ -224,7 +224,7 @@ public:
   typedef internal::EigenMappedDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                        BackendType;
   typedef typename Traits::ScalarType                         ScalarType;
-  typedef typename Traits::RealScalarType                     RealScalarType;
+  typedef typename Traits::RealType                           RealType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;
@@ -364,7 +364,7 @@ public:
   typedef internal::EigenDenseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                  BackendType;
   typedef typename Traits::ScalarType                   ScalarType;
-  typedef typename Traits::RealScalarType               RealScalarType;
+  typedef typename Traits::RealType                     RealType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;

--- a/dune/stuff/la/container/eigen/dense.hh
+++ b/dune/stuff/la/container/eigen/dense.hh
@@ -62,7 +62,8 @@ template< class ScalarImp = double >
 class EigenDenseVectorTraits
 {
 public:
-  typedef ScalarImp                      ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef EigenDenseVector< ScalarType > derived_type;
   typedef typename ::Eigen::Matrix< ScalarType, ::Eigen::Dynamic, 1 > BackendType;
 }; // class EigenDenseVectorTraits
@@ -76,7 +77,8 @@ class EigenMappedDenseVectorTraits
 {
   typedef typename ::Eigen::Matrix< ScalarImp, ::Eigen::Dynamic, 1 > PlainBackendType;
 public:
-  typedef ScalarImp                            ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef EigenMappedDenseVector< ScalarType > derived_type;
   typedef Eigen::Map< PlainBackendType >       BackendType;
 }; // class EigenMappedDenseVectorTraits
@@ -104,17 +106,18 @@ public:
  */
 template< class ScalarImp = double>
 class EigenDenseVector
-  : public EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp > >
+  : public EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp >
   , public ProvidesDataAccess< internal::EigenDenseVectorTraits< ScalarImp > >
 {
   typedef EigenDenseVector< ScalarImp >                                               ThisType;
   typedef VectorInterface< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp > VectorInterfaceType;
-  typedef EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp > >            BaseType;
+  typedef EigenBaseVector< internal::EigenDenseVectorTraits< ScalarImp >, ScalarImp >            BaseType;
   static_assert(!std::is_same< DUNE_STUFF_SSIZE_T, int >::value,
                 "You have to manually disable the constructor below which uses DUNE_STUFF_SSIZE_T!");
 public:
   typedef internal::EigenDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                   ScalarType;
+  typedef typename Traits::RealScalarType               RealScalarType;
   typedef typename Traits::BackendType                  BackendType;
 
 private:
@@ -200,7 +203,7 @@ private:
       backend_ = std::make_shared< BackendType >(*(backend_));
   } // ... ensure_uniqueness(...)
 
-  friend class EigenBaseVector< internal::EigenDenseVectorTraits< ScalarType > >;
+  friend class EigenBaseVector< internal::EigenDenseVectorTraits< ScalarType >, ScalarType >;
 }; // class EigenDenseVector
 
 
@@ -209,11 +212,11 @@ private:
  */
 template< class ScalarImp = double >
 class EigenMappedDenseVector
-  : public EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp > >
+  : public EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp >
 {
   typedef EigenMappedDenseVector< ScalarImp >                                               ThisType;
   typedef VectorInterface< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp > VectorInterfaceType;
-  typedef EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp > >            BaseType;
+  typedef EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarImp >, ScalarImp >            BaseType;
   static_assert(std::is_same< ScalarImp, double >::value, "Undefined behaviour for non-double data!");
   static_assert(!std::is_same< DUNE_STUFF_SSIZE_T, int >::value,
                 "You have to manually disable the constructor below which uses DUNE_STUFF_SSIZE_T!");
@@ -221,6 +224,7 @@ public:
   typedef internal::EigenMappedDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                        BackendType;
   typedef typename Traits::ScalarType                         ScalarType;
+  typedef typename Traits::RealScalarType                     RealScalarType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;
@@ -339,7 +343,7 @@ private:
     }
   } // ... ensure_uniqueness(...)
 
-  friend class EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarType > >;
+  friend class EigenBaseVector< internal::EigenMappedDenseVectorTraits< ScalarType >, ScalarType >;
 }; // class EigenMappedDenseVector
 
 

--- a/dune/stuff/la/container/eigen/dense.hh
+++ b/dune/stuff/la/container/eigen/dense.hh
@@ -10,6 +10,7 @@
 #include <type_traits>
 #include <vector>
 #include <initializer_list>
+#include <complex>
 
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -21,6 +22,7 @@
 
 #include <dune/common/typetraits.hh>
 #include <dune/common/densematrix.hh>
+#include <dune/common/ftraits.hh>
 
 #include <dune/stuff/aliases.hh>
 #include <dune/stuff/common/exceptions.hh>
@@ -87,7 +89,8 @@ template< class ScalarImp = double >
 class EigenDenseMatrixTraits
 {
 public:
-  typedef ScalarImp                      ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef EigenDenseMatrix< ScalarType > derived_type;
   typedef typename ::Eigen::Matrix< ScalarType, ::Eigen::Dynamic, ::Eigen::Dynamic > BackendType;
 }; // class EigenDenseMatrixTraits
@@ -357,6 +360,7 @@ public:
   typedef internal::EigenDenseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                  BackendType;
   typedef typename Traits::ScalarType                   ScalarType;
+  typedef typename Traits::RealScalarType               RealScalarType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;
@@ -593,7 +597,7 @@ public:
     for (size_t ii = 0; ii < rows(); ++ii) {
       for (size_t jj = 0; jj < cols(); ++jj) {
         const auto& entry = backend_->operator()(ii, jj);
-        if (std::isnan(entry) || std::isinf(entry))
+        if (std::isnan(std::real(entry)) || std::isnan(std::imag(entry)) || std::isinf(std::abs(entry)))
           return false;
       }
     }

--- a/dune/stuff/la/container/eigen/sparse.hh
+++ b/dune/stuff/la/container/eigen/sparse.hh
@@ -9,6 +9,7 @@
 #include <memory>
 #include <type_traits>
 #include <vector>
+#include <complex>
 
 #include <boost/numeric/conversion/cast.hpp>
 
@@ -19,6 +20,7 @@
 #include <dune/stuff/common/reenable_warnings.hh>
 
 #include <dune/common/typetraits.hh>
+#include <dune/common/ftraits.hh>
 
 #include <dune/stuff/aliases.hh>
 #include <dune/stuff/common/exceptions.hh>
@@ -55,7 +57,8 @@ template< class ScalarImp = double >
 class EigenRowMajorSparseMatrixTraits
 {
 public:
-  typedef ScalarImp                               ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef EigenRowMajorSparseMatrix< ScalarType > derived_type;
   typedef typename ::Eigen::SparseMatrix< ScalarType, ::Eigen::RowMajor > BackendType;
 }; // class RowMajorSparseMatrixTraits
@@ -80,6 +83,7 @@ public:
   typedef internal::EigenRowMajorSparseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                           BackendType;
   typedef typename Traits::ScalarType                            ScalarType;
+  typedef typename Traits::RealScalarType                        RealScalarType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;

--- a/dune/stuff/la/container/eigen/sparse.hh
+++ b/dune/stuff/la/container/eigen/sparse.hh
@@ -57,9 +57,9 @@ template< class ScalarImp = double >
 class EigenRowMajorSparseMatrixTraits
 {
 public:
-  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef EigenRowMajorSparseMatrix< ScalarType > derived_type;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type             ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type              RealType;
+  typedef EigenRowMajorSparseMatrix< ScalarType >                         derived_type;
   typedef typename ::Eigen::SparseMatrix< ScalarType, ::Eigen::RowMajor > BackendType;
 }; // class RowMajorSparseMatrixTraits
 
@@ -83,7 +83,7 @@ public:
   typedef internal::EigenRowMajorSparseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                           BackendType;
   typedef typename Traits::ScalarType                            ScalarType;
-  typedef typename Traits::RealScalarType                        RealScalarType;
+  typedef typename Traits::RealType                              RealType;
 
 private:
   typedef typename BackendType::Index EIGEN_size_t;

--- a/dune/stuff/la/container/istl.hh
+++ b/dune/stuff/la/container/istl.hh
@@ -53,7 +53,8 @@ template< class ScalarImp >
 class IstlDenseVectorTraits
 {
 public:
-  typedef ScalarImp ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef IstlDenseVector< ScalarImp >                derived_type;
   typedef BlockVector< FieldVector< ScalarType, 1 > > BackendType;
 }; // class IstlDenseVectorTraits
@@ -91,6 +92,7 @@ class IstlDenseVector
 public:
   typedef internal::IstlDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                  ScalarType;
+  typedef typename Traits::RealScalarType              RealScalarType;
   typedef typename Traits::BackendType                 BackendType;
 
   explicit IstlDenseVector(const size_t ss = 0, const ScalarType value = ScalarType(0))
@@ -263,17 +265,17 @@ public:
     return backend_->dot(*(other.backend_));
   } // ... dot(...)
 
-  virtual ScalarType l1_norm() const override final
+  virtual RealScalarType l1_norm() const override final
   {
     return backend_->one_norm();
   }
 
-  virtual ScalarType l2_norm() const override final
+  virtual RealScalarType l2_norm() const override final
   {
     return backend_->two_norm();
   }
 
-  virtual ScalarType sup_norm() const override final
+  virtual RealScalarType sup_norm() const override final
   {
     return backend_->infinity_norm();
   }

--- a/dune/stuff/la/container/istl.hh
+++ b/dune/stuff/la/container/istl.hh
@@ -10,12 +10,14 @@
 
 #include <vector>
 #include <initializer_list>
+#include <complex>
 
 #include <boost/numeric/conversion/cast.hpp>
 
 #include <dune/common/fmatrix.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/typetraits.hh>
+#include <dune/common/ftraits.hh>
 
 #if HAVE_DUNE_ISTL
 # include <dune/istl/bvector.hh>
@@ -64,7 +66,8 @@ template< class ScalarImp >
 class IstlRowMajorSparseMatrixTraits
 {
 public:
-  typedef ScalarImp ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
   typedef IstlRowMajorSparseMatrix< ScalarType >        derived_type;
   typedef BCRSMatrix< FieldMatrix< ScalarType, 1, 1 > > BackendType;
 }; // class RowMajorSparseMatrixTraits
@@ -370,6 +373,7 @@ public:
   typedef internal::IstlRowMajorSparseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                          BackendType;
   typedef typename Traits::ScalarType                           ScalarType;
+  typedef typename Traits::RealScalarType                       RealScalarType;
 
   /**
    * \brief This is the constructor of interest which creates a sparse matrix.
@@ -591,7 +595,7 @@ public:
       for (size_t jj = 0; jj < cols(); ++jj)
         if (backend_->exists(ii, jj)) {
           const auto& entry = row_vec[jj][0];
-          if (std::isnan(entry) || std::isinf(entry))
+          if (std::isnan(entry.two_norm()) || std::isinf(entry.two_norm()))
             return false;
         }
     }

--- a/dune/stuff/la/container/istl.hh
+++ b/dune/stuff/la/container/istl.hh
@@ -597,7 +597,7 @@ public:
       for (size_t jj = 0; jj < cols(); ++jj)
         if (backend_->exists(ii, jj)) {
           const auto& entry = row_vec[jj][0];
-          if (std::isnan(entry.two_norm()) || std::isinf(entry.two_norm()))
+          if (std::isnan(std::real(entry[0])) || std::isnan(std::imag(entry[0])) || std::isinf(std::abs(entry[0])))
             return false;
         }
     }

--- a/dune/stuff/la/container/istl.hh
+++ b/dune/stuff/la/container/istl.hh
@@ -54,9 +54,9 @@ class IstlDenseVectorTraits
 {
 public:
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef IstlDenseVector< ScalarImp >                derived_type;
-  typedef BlockVector< FieldVector< ScalarType, 1 > > BackendType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
+  typedef IstlDenseVector< ScalarImp >                        derived_type;
+  typedef BlockVector< FieldVector< ScalarType, 1 > >         BackendType;
 }; // class IstlDenseVectorTraits
 
 
@@ -68,9 +68,9 @@ class IstlRowMajorSparseMatrixTraits
 {
 public:
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
-  typedef IstlRowMajorSparseMatrix< ScalarType >        derived_type;
-  typedef BCRSMatrix< FieldMatrix< ScalarType, 1, 1 > > BackendType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
+  typedef IstlRowMajorSparseMatrix< ScalarType >              derived_type;
+  typedef BCRSMatrix< FieldMatrix< ScalarType, 1, 1 > >       BackendType;
 }; // class RowMajorSparseMatrixTraits
 
 
@@ -92,7 +92,7 @@ class IstlDenseVector
 public:
   typedef internal::IstlDenseVectorTraits< ScalarImp > Traits;
   typedef typename Traits::ScalarType                  ScalarType;
-  typedef typename Traits::RealScalarType              RealScalarType;
+  typedef typename Traits::RealType                    RealType;
   typedef typename Traits::BackendType                 BackendType;
 
   explicit IstlDenseVector(const size_t ss = 0, const ScalarType value = ScalarType(0))
@@ -265,17 +265,17 @@ public:
     return backend_->dot(*(other.backend_));
   } // ... dot(...)
 
-  virtual RealScalarType l1_norm() const override final
+  virtual RealType l1_norm() const override final
   {
     return backend_->one_norm();
   }
 
-  virtual RealScalarType l2_norm() const override final
+  virtual RealType l2_norm() const override final
   {
     return backend_->two_norm();
   }
 
-  virtual RealScalarType sup_norm() const override final
+  virtual RealType sup_norm() const override final
   {
     return backend_->infinity_norm();
   }
@@ -375,7 +375,7 @@ public:
   typedef internal::IstlRowMajorSparseMatrixTraits< ScalarImp > Traits;
   typedef typename Traits::BackendType                          BackendType;
   typedef typename Traits::ScalarType                           ScalarType;
-  typedef typename Traits::RealScalarType                       RealScalarType;
+  typedef typename Traits::RealType                             RealType;
 
   /**
    * \brief This is the constructor of interest which creates a sparse matrix.

--- a/dune/stuff/la/container/matrix-interface.hh
+++ b/dune/stuff/la/container/matrix-interface.hh
@@ -46,9 +46,9 @@ class MatrixInterface
   , public Tags::MatrixInterface
 {
 public:
-  typedef typename Traits::derived_type derived_type;
+  typedef typename Traits::derived_type                       derived_type;
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
 
   virtual ~MatrixInterface() {}
 
@@ -132,9 +132,9 @@ public:
     return yy;
   }
 
-  virtual RealScalarType sup_norm() const
+  virtual RealType sup_norm() const
   {
-    RealScalarType ret = 0;
+    RealType ret = 0;
     for (size_t ii = 0; ii < rows(); ++ii)
       for (size_t jj = 0; jj < cols(); ++jj)
         ret = std::max(ret, std::abs(get_entry(ii, jj)));

--- a/dune/stuff/la/container/matrix-interface.hh
+++ b/dune/stuff/la/container/matrix-interface.hh
@@ -13,6 +13,8 @@
 #include <iostream>
 #include <type_traits>
 
+#include <dune/common/ftraits.hh>
+
 #include <dune/stuff/common/crtp.hh>
 #include <dune/stuff/common/exceptions.hh>
 #include <dune/stuff/common/matrix.hh>
@@ -45,7 +47,8 @@ class MatrixInterface
 {
 public:
   typedef typename Traits::derived_type derived_type;
-  typedef ScalarImp                     ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
 
   virtual ~MatrixInterface() {}
 
@@ -129,9 +132,9 @@ public:
     return yy;
   }
 
-  virtual ScalarType sup_norm() const
+  virtual RealScalarType sup_norm() const
   {
-    ScalarType ret = 0;
+    RealScalarType ret = 0;
     for (size_t ii = 0; ii < rows(); ++ii)
       for (size_t jj = 0; jj < cols(); ++jj)
         ret = std::max(ret, std::abs(get_entry(ii, jj)));

--- a/dune/stuff/la/container/vector-interface.hh
+++ b/dune/stuff/la/container/vector-interface.hh
@@ -669,6 +669,8 @@ struct VectorAbstractionBase
   typedef typename std::conditional< is_vector, VectorImp, void >::type                      VectorType;
   typedef typename std::conditional< is_vector, typename VectorImp::ScalarType, void >::type ScalarType;
   typedef ScalarType S;
+  typedef typename std::conditional< is_vector, typename VectorImp::RealScalarType, void >::type RealScalarType;
+  typedef RealScalarType R;
 
   static inline
     typename std::enable_if< is_vector, VectorType >::type

--- a/dune/stuff/la/container/vector-interface.hh
+++ b/dune/stuff/la/container/vector-interface.hh
@@ -50,9 +50,9 @@ class VectorInterface
   , public Tags::VectorInterface
 {
 public:
-  typedef typename Traits::derived_type derived_type;
+  typedef typename Traits::derived_type                       derived_type;
   typedef typename Dune::FieldTraits< ScalarImp >::field_type ScalarType;
-  typedef typename Dune::FieldTraits< ScalarImp >::real_type RealScalarType;
+  typedef typename Dune::FieldTraits< ScalarImp >::real_type  RealType;
 
   typedef internal::VectorInputIterator< Traits, ScalarType >  const_iterator;
   typedef internal::VectorOutputIterator< Traits, ScalarType > iterator;
@@ -169,9 +169,9 @@ public:
    *  \return A pair of the lowest index at which the maximum is attained and the absolute maximum value.
    *  \note   If you override this method please use exceptions instead of assertions (for the python bindings).
    */
-  virtual std::pair< size_t, RealScalarType > amax() const
+  virtual std::pair< size_t, RealType > amax() const
   {
-    auto result = std::make_pair(size_t(0), RealScalarType(0));
+    auto result = std::make_pair(size_t(0), RealType(0));
     for (size_t ii = 0; ii < size(); ++ii) {
       const auto value = std::abs(get_entry_ref(ii));
       if (value > result.second) {
@@ -192,7 +192,7 @@ public:
    *  \note   If you override this method please use exceptions instead of assertions (for the python bindings).
    */
   virtual bool almost_equal(const derived_type& other,
-                            const RealScalarType epsilon = Stuff::Common::FloatCmp::DefaultEpsilon< RealScalarType >::value()) const
+                            const RealType epsilon = Stuff::Common::FloatCmp::DefaultEpsilon< RealType >::value()) const
   {
     if (other.size() != size())
       DUNE_THROW(Exceptions::shapes_do_not_match,
@@ -211,7 +211,7 @@ public:
    */
   template< class T >
   bool almost_equal(const VectorInterface< T >& other,
-                    const RealScalarType epsilon = Stuff::Common::FloatCmp::DefaultEpsilon< RealScalarType >::value()) const
+                    const RealType epsilon = Stuff::Common::FloatCmp::DefaultEpsilon< RealType >::value()) const
   {
     if (other.size() != size())
       DUNE_THROW(Exceptions::shapes_do_not_match,
@@ -243,9 +243,9 @@ public:
    *  \return The l1-norm of the vector.
    *  \note   If you override this method please use exceptions instead of assertions (for the python bindings).
    */
-  virtual RealScalarType l1_norm() const
+  virtual RealType l1_norm() const
   {
-    RealScalarType result = 0;
+    RealType result = 0;
     for (size_t ii = 0; ii < size(); ++ii)
       result += std::abs(get_entry_ref(ii));
     return result;
@@ -256,7 +256,7 @@ public:
    *  \return The l2-norm of the vector.
    *  \note   If you override this method please use exceptions instead of assertions (for the python bindings).
    */
-  virtual RealScalarType l2_norm() const
+  virtual RealType l2_norm() const
   {
     return std::sqrt(std::abs(dot(this->as_imp(*this)))); //std::abs is only needed for the right return type:
                                                          //v.dot(v) should always be a ScalarType with zero imaginary part
@@ -267,7 +267,7 @@ public:
    *  \return The l-infintiy-norm of the vector.
    *  \note   If you override this method please use exceptions instead of assertions (for the python bindings).
    */
-  virtual RealScalarType sup_norm() const
+  virtual RealType sup_norm() const
   {
     return amax().second;
   }
@@ -555,15 +555,15 @@ public:
    * \brief Variant of amax() needed for the python bindings.
    * \see   amax()
    */
-  std::vector< RealScalarType > pb_amax() const
+  std::vector< RealType > pb_amax() const
   {
     const auto max = amax();
     try {
-      return { boost::numeric_cast< RealScalarType >(max.first), max.second};
+      return { boost::numeric_cast< RealType >(max.first), max.second};
     } catch (boost::bad_numeric_cast& ee) {
       DUNE_THROW(Exceptions::external_error,
                  "There was an error in boost converting '" << max.first << "' to '"
-                 << Common::Typename< RealScalarType >::value() << "': " << ee.what());
+                 << Common::Typename< RealType >::value() << "': " << ee.what());
     }
   } // ... pb_amax(...)
 
@@ -668,9 +668,9 @@ struct VectorAbstractionBase
 
   typedef typename std::conditional< is_vector, VectorImp, void >::type                      VectorType;
   typedef typename std::conditional< is_vector, typename VectorImp::ScalarType, void >::type ScalarType;
+  typedef typename std::conditional< is_vector, typename VectorImp::RealType, void >::type   RealType;
   typedef ScalarType S;
-  typedef typename std::conditional< is_vector, typename VectorImp::RealScalarType, void >::type RealScalarType;
-  typedef RealScalarType R;
+  typedef RealType   R;
 
   static inline
     typename std::enable_if< is_vector, VectorType >::type


### PR DESCRIPTION
I tried to implement complex-valued matrices and vectors, please have a look at it. Some quick (and easy) tests worked for me. Still, there are three points I'm not quite sure about:

1)whether the implementation of IstlRowMajorSparseMatrix.valid() really detects nan and infinity. Maybe, the two_norm() rather gives an error when an entry is nan or infinity -- I haven't tested this yet.
2) whether it is a good idea to implement float_cmp::eq also for complex-valued xtype and ytype. However, this is needed for complex-valued vectors in the member function almost_equal().
3) the static assertion for ScalarImp=double in EigenMappedDenseVector: I left it as it was, but now it gives a failure in the method valid() for complex-valued EigenRowMajorSparseMatrix.
