### PR TITLE
Expression function for dimRangeCols > 1

### DIFF
--- a/dune/stuff/functions/checkerboard.hh
+++ b/dune/stuff/functions/checkerboard.hh
@@ -66,10 +66,22 @@ class Checkerboard
     virtual void jacobian(const DomainType& UNUSED_UNLESS_DEBUG(xx), JacobianRangeType& ret) const override
     {
       assert(this->is_a_valid_point(xx));
-      ret *= RangeFieldType(0);
+      jacobian_helper(ret, internal::ChooseVariant< rangeDimCols >());
     }
 
   private:
+    template< size_t rC >
+    void jacobian_helper(JacobianRangeType& ret, internal::ChooseVariant< rC >) const
+    {
+      for (auto& col_jacobian: ret) {
+        col_jacobian *= RangeFieldType(0);
+      }
+    }
+
+    void jacobian_helper(JacobianRangeType& ret, internal::ChooseVariant< 1 >) const
+    {
+      ret *= RangeFieldType(0);
+    }
     const RangeType value_;
   }; // class Localfunction
 

--- a/dune/stuff/functions/constant.hh
+++ b/dune/stuff/functions/constant.hh
@@ -178,7 +178,7 @@ public:
 
   virtual void jacobian(const DomainType& /*x*/, JacobianRangeType& ret) const override final
   {
-    ret *= 0.0;
+    jacobian_helper(ret, internal::ChooseVariant< rangeDimCols >());
   }
 
   virtual std::string name() const override final
@@ -187,6 +187,18 @@ public:
   }
 
 private:
+  template< size_t rC >
+  void jacobian_helper(JacobianRangeType& ret, internal::ChooseVariant< rC >) const
+  {
+    for (auto& col_jacobian: ret) {
+      col_jacobian *= 0;
+    }
+  }
+
+  void jacobian_helper(JacobianRangeType& ret, internal::ChooseVariant< 1 >) const
+  {
+    ret *= 0;
+  }
   const RangeType constant_;
   const std::string name_;
 };

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -83,7 +83,7 @@ public:
       get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< dimRangeCols >());
     } catch (Exceptions::conversion_error) {
       // if dimRangeCols == 1 and we could not get expression as FieldVector, get it as FieldMatrix with one col
-      if (dimRangeCols == 1) {
+      if (dimRangeCols == 1) { // the 2 in ChooseVariant is here on purpose, anything > 1 will suffice
         get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< 2 >());
       } else { // if dimRangeCols > 1 do the same again (to throw exception without catching it)
         get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< dimRangeCols >());

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -127,11 +127,12 @@ public:
     const std::vector< std::string > expression_row(dimRangeCols, expression);
     const ExpressionStringVectorType expressions(dimRange, expression_row);
     // create associated gradient vector
-    GradientStringVectorType gradient_expressions(dimRangeCols);
-    assert(gradient.size() >= dimDomain);
-    const ExpressionStringVectorType gradient_row(dimRange, gradient);
-    for (size_t cc = 0; cc < dimRangeCols; ++cc) {
-      gradient_expressions[cc] = gradient_row;
+    GradientStringVectorType gradient_expressions;
+    if (gradient.size() > 0) {
+      const std::vector< std::vector< std::string > > gradient_row(dimRange, gradient);
+      for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+        gradient_expressions.emplace_back(gradient_row);
+      }
     }
     // build function and gradient
     build_function(variable, expressions);
@@ -287,7 +288,7 @@ private:
         assert(gradient_expressions[cc].size() >= dimRange);
         for (size_t rr = 0; rr < dimRange; ++rr) {
           const auto& gradient_expression = gradient_expressions[cc][rr];
-          assert(gradient_expressions[cc][rr].size() >= dimDomain);
+          assert(gradient_expression.size() >= dimDomain);
           gradients_[cc].emplace_back(new MathExpressionGradientType(variable, gradient_expression));
         }
       }

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -148,8 +148,8 @@ public:
              const std::vector< std::string > expressions,
              const size_t ord = default_config().get< size_t >("order"),
              const std::string nm = static_id(),
-             const ExpressionStringVectorType gradient_expressions
-                = ExpressionStringVectorType())
+             const std::vector< std::vector< std::string > > gradient_expressions
+                = std::vector< std::vector< std::string > >())
     : function_(new MathExpressionFunctionType(variable, expressions))
     , order_(ord)
     , name_(nm)

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -3,7 +3,7 @@
 // Copyright holders: Rene Milk, Felix Schindler
 // License: BSD 2-Clause License (http://opensource.org/licenses/BSD-2-Clause)
 //
-// Contributors: Kirsten Weber
+// Contributors: Kirsten Weber, Tobias Leibner
 
 #ifndef DUNE_STUFF_FUNCTIONS_EXPRESSION_HH
 #define DUNE_STUFF_FUNCTIONS_EXPRESSION_HH
@@ -11,6 +11,7 @@
 #include <vector>
 #include <limits>
 
+#include <dune/common/fmatrix.hh>
 #include <dune/common/fvector.hh>
 
 #include <dune/stuff/common/configuration.hh>
@@ -19,110 +20,181 @@
 #include "expression/base.hh"
 #include "interfaces.hh"
 #include "default.hh"
-#include "constant.hh"
 
 namespace Dune {
 namespace Stuff {
 namespace Functions {
+namespace internal {
 
 
-/**
- *  \attention  If you add the create() and default_config() method, do not forget to enable the matrix valued
- *              versions in test/function_expression.cc
- */
+template< size_t rangeDimCols >
+struct ChooseVariant {};
+
+
+} // namespace internal
+
+
 template< class EntityImp, class DomainFieldImp, size_t domainDim, class RangeFieldImp, size_t rangeDim, size_t rangeDimCols = 1 >
 class Expression
-  : public LocalizableFunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols >
+  : public GlobalFunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols >
 {
   typedef LocalizableFunctionInterface
       < EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols >               BaseType;
   typedef Expression< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols > ThisType;
   typedef MathExpressionBase
       < DomainFieldImp, domainDim, RangeFieldImp, rangeDim*rangeDimCols > MathExpressionFunctionType;
-
-  class Localfunction
-    : public LocalfunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols >
-  {
-    typedef LocalfunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, rangeDimCols > BaseType;
-  public:
-    typedef typename BaseType::EntityType EntityType;
-
-    typedef typename BaseType::DomainType     DomainType;
-    typedef typename BaseType::RangeFieldType RangeFieldType;
-    static const size_t                       dimRange = BaseType::dimRange;
-    static const size_t                       dimRangeCols = BaseType::dimRangeCols;
-    typedef typename BaseType::RangeType      RangeType;
-
-    typedef typename BaseType::JacobianRangeType JacobianRangeType;
-
-    Localfunction(const EntityType& ent,
-                  const std::shared_ptr< const MathExpressionFunctionType >& function,
-                  const size_t ord)
-      : BaseType(ent)
-      , function_(function)
-      , order_(ord)
-      , tmp_vector_(0)
-    {}
-
-    Localfunction(const Localfunction& /*other*/) = delete;
-
-    Localfunction& operator=(const Localfunction& /*other*/) = delete;
-
-    virtual size_t order() const override
-    {
-      return order_;
-    }
-
-    virtual void evaluate(const DomainType& xx, RangeType& ret) const override
-    {
-      function_->evaluate(this->entity().geometry().global(xx), tmp_vector_);
-      for (size_t ii = 0; ii < dimRange; ++ii) {
-        auto& retRow = ret[ii];
-        for (size_t jj = 0; jj < dimRangeCols; ++jj) {
-          retRow[jj] = tmp_vector_[ii*dimRange + jj];
-        }
-      }
-    } // ... evaluate(...)
-
-    virtual void jacobian(const DomainType& /*xx*/, JacobianRangeType& /*ret*/) const override
-    {
-      DUNE_THROW(NotImplemented,
-                 "Once we decided on the JacobianRangeType of matrix valued functions we have to implement "
-                 << "gradients for this function!");
-    }
-
-  private:
-    const std::shared_ptr< const MathExpressionFunctionType > function_;
-    const size_t order_;
-    mutable FieldVector< RangeFieldType, dimRange*dimRangeCols > tmp_vector_;
-  }; // class Localfunction
+  typedef MathExpressionBase < DomainFieldImp, domainDim, RangeFieldImp, domainDim > MathExpressionGradientType;
 
 public:
-  typedef typename BaseType::EntityType         EntityType;
-  typedef typename BaseType::LocalfunctionType  LocalfunctionType;
+  using typename BaseType::EntityType;
+  using typename BaseType::DomainType;
+  using typename BaseType::RangeFieldType;
+  using BaseType::dimDomain;
+  using BaseType::dimRange;
+  using BaseType::dimRangeCols;
+  using typename BaseType::RangeType;
+  using typename BaseType::JacobianRangeType;
+  typedef typename std::vector< std::vector< std::string > >                ExpressionStringVectorType;
+  typedef typename std::vector< std::vector< std::vector< std::string > > > GradientStringVectorType;
 
   static std::string static_id()
   {
     return BaseType::static_id() + ".expression";
   }
 
+  static Common::Configuration default_config(const std::string sub_name = "")
+  {
+    Common::Configuration config;
+    config["variable"] = "x";
+    config["expression"] = "[x[0] sin(x[0]) exp(x[0]); x[0] sin(x[0]) exp(x[0]); x[0] sin(x[0]) exp(x[0])]";
+    config["order"] = "3";
+    config["name"] = static_id();
+    if (sub_name.empty())
+      return config;
+    else {
+      Common::Configuration tmp;
+      tmp.add(config, sub_name);
+      return tmp;
+    }
+  } // ... default_config(...)
+
+  static std::unique_ptr< ThisType > create(const Common::Configuration config = default_config(),
+                                            const std::string sub_name = static_id())
+  {
+    // get correct config
+    const Common::Configuration cfg = config.has_sub(sub_name) ? config.sub(sub_name) : config;
+    const Common::Configuration default_cfg = default_config();
+    // get expression
+    ExpressionStringVectorType expression_as_vectors;
+    // try to get expression as FieldVector (if dimRangeCols == 1) or as FieldMatrix (else)
+    try {
+      get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< dimRangeCols >());
+    } catch (Exceptions::conversion_error) {
+      // if dimRangeCols == 1 and we could not get expression as FieldVector, get it as FieldMatrix with one col
+      if (dimRangeCols == 1) {
+        get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< 2 >());
+      } else { // if dimRangeCols > 1 do the same again (to throw exception without catching it)
+        get_expression_helper(cfg, expression_as_vectors, internal::ChooseVariant< dimRangeCols >());
+      }
+    }
+    // get gradient
+    GradientStringVectorType gradient_as_vectors;
+    if (cfg.has_key("gradient")) {
+      if (cfg.has_key("gradient.0"))
+        assert((cfg.get< std::string >("gradient") == cfg.get< std::string >("gradient.0"))
+               && "gradient and gradient.0 differ but should be synonymous!");
+      get_gradient(cfg, gradient_as_vectors, "gradient");
+    } else if (cfg.has_key("gradient.0")) {
+      get_gradient(cfg, gradient_as_vectors, "gradient.0");
+    }
+    // create
+    return Common::make_unique< ThisType >(
+          cfg.get("variable",   default_cfg.get< std::string >("variable")),
+          expression_as_vectors,
+          cfg.get("order",      default_cfg.get< size_t >("order")),
+          cfg.get("name",       default_cfg.get< std::string >("name")),
+          gradient_as_vectors);
+  } // ... create(...)
+
+  /**
+   * \brief Creates an Expression function where every component is identical
+   *
+   * For example, if dimDomain = dimRange = dimRangeCols = 2 and expression = "x[0]*x[1]", gradient should be
+   * ["x[1]" "x[0]"]. Then the resulting function is [x[0]*x[1] x[0]*x[1]; x[0]*x[1] x[0]*x[1]] and the gradient is
+   * [[x[1] x[0]; x[1] x[0]] [x[1] x[0] x[1] x[0]].
+   */
   Expression(const std::string variable,
              const std::string expression,
              const size_t ord = 0,
-             const std::string nm = static_id())
-    : function_(new MathExpressionFunctionType(variable, expression))
-    , order_(ord)
+             const std::string nm = static_id(),
+             const std::vector< std::string > gradient = std::vector< std::string >())
+    : order_(ord)
     , name_(nm)
-  {}
+  {
+    // create ExpressionStringVectorType with identical expressions
+    const std::vector< std::string > expression_row(dimRangeCols, expression);
+    const ExpressionStringVectorType expressions(dimRange, expression_row);
+    // create associated gradient vector
+    GradientStringVectorType gradient_expressions(dimRangeCols);
+    assert(gradient.size() >= dimDomain);
+    const ExpressionStringVectorType gradient_row(dimRange, gradient);
+    for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+      gradient_expressions[cc] = gradient_row;
+    }
+    // build function and gradient
+    build_function(variable, expressions);
+    build_gradients(variable, gradient_expressions);
+  }
 
+  /**
+   * \brief Creates an Expression function with dimRangeCols = 1
+   *
+   * This constructor just expands expressions and gradient_expressions from a std::vector< std::string > and
+   * std::vector< std::vector< std::string > to ExpressionStringVectorType and GradientStringVectorType, respectively.
+   */
   Expression(const std::string variable,
              const std::vector< std::string > expressions,
-             const size_t ord = 0,
-             const std::string nm = static_id())
+             const size_t ord = default_config().get< size_t >("order"),
+             const std::string nm = static_id(),
+             const ExpressionStringVectorType gradient_expressions
+                = ExpressionStringVectorType())
     : function_(new MathExpressionFunctionType(variable, expressions))
     , order_(ord)
     , name_(nm)
-  {}
+  {
+    static_assert(dimRangeCols == 1, "This constructor does not make sense for dimRangeCols > 1!");
+    GradientStringVectorType gradient_expressions_vec;
+    if (gradient_expressions.size() > 0) {
+      gradient_expressions_vec.emplace_back(gradient_expressions);
+    }
+    build_gradients(variable, gradient_expressions_vec);
+  }
+
+  /**
+   * \brief Creates an Expression function
+   *
+   * \param variable variable of the Expression function, e.g. "x"
+   * \param expressions vector< vector< string > >, where the inner vectors are the rows of the Expression functions
+   *  range, e.g. [[1 sin(x[0])] [2*x[0] x[1]]] gives the range [1 sin(x[0]); 2 x[1]]
+   * \param ord order of the Expression function
+   * \param nm name of the Expression function
+   * \param gradient_expressions vector< vector< vector< string > > >, vector of the jacobian matrices (written as
+   *  vector< vector< string > >, where the inner vectors are the rows) of the columns of the Expression function, e.g.
+   *  [[[0 0] [2 0]] [[cos(x[0]) 0] [0 1]]] would be the gradient_expression corresponding to the expression above (if
+   *  dimDomain = dimRange = dimRangeCols = 2)
+   */
+  Expression(const std::string variable,
+             const ExpressionStringVectorType expressions,
+             const size_t ord = 0,
+             const std::string nm = static_id(),
+             const GradientStringVectorType gradient_expressions
+                = GradientStringVectorType())
+    : order_(ord)
+    , name_(nm)
+  {
+    build_function(variable, expressions);
+    build_gradients(variable, gradient_expressions);
+  }
 
   Expression(const ThisType& other) = default;
 
@@ -132,6 +204,7 @@ public:
       function_ = other.function_;
       order_ = other.order_;
       name_ = other.name_;
+      gradients_ = other.gradients_;
     }
     return *this;
   }
@@ -146,121 +219,6 @@ public:
     return name_;
   }
 
-  virtual std::unique_ptr< LocalfunctionType > local_function(const EntityType& entity) const override
-  {
-    return std::unique_ptr< Localfunction >(new Localfunction(entity, function_, order_));
-  }
-
-private:
-  std::shared_ptr< const MathExpressionFunctionType > function_;
-  size_t order_;
-  std::string name_;
-}; // class Expression
-
-
-template< class EntityImp, class DomainFieldImp, size_t domainDim, class RangeFieldImp, size_t rangeDim >
-class Expression< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, 1 >
-  : public GlobalFunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim >
-{
-  typedef GlobalFunctionInterface< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim > BaseType;
-  typedef Expression< EntityImp, DomainFieldImp, domainDim, RangeFieldImp, rangeDim, 1 > ThisType;
-  typedef MathExpressionBase < DomainFieldImp, domainDim, RangeFieldImp, rangeDim > MathExpressionFunctionType;
-  typedef MathExpressionBase < DomainFieldImp, domainDim, RangeFieldImp, domainDim > MathExpressionGradientType;
-
-public:
-  typedef typename BaseType::EntityType         EntityType;
-  typedef typename BaseType::LocalfunctionType  LocalfunctionType;
-
-  static const size_t                   dimDomain = BaseType::dimDomain;
-  typedef typename BaseType::DomainType DomainType;
-
-  static const size_t                   dimRange = BaseType::dimRange;
-  typedef typename BaseType::RangeType  RangeType;
-
-  typedef typename BaseType::JacobianRangeType JacobianRangeType;
-
-  static const bool available = true;
-
-  static std::string static_id()
-  {
-    return BaseType::static_id() + ".expression";
-  }
-
-  static Common::Configuration default_config(const std::string sub_name = "")
-  {
-    Common::Configuration config;
-    config["variable"] = "x";
-    config["expression"] = "[x[0] sin(x[0]) exp(x[0])]";
-    config["order"] = "3";
-    config["name"] = static_id();
-    if (sub_name.empty())
-      return config;
-    else {
-      Common::Configuration tmp;
-      tmp.add(config, sub_name);
-      return tmp;
-    }
-  } // ... default_config(...)
-
-  static std::unique_ptr< ThisType > create(const Common::Configuration config = default_config(), const std::string sub_name = static_id())
-  {
-    // get correct config
-    const Common::Configuration cfg = config.has_sub(sub_name) ? config.sub(sub_name) : config;
-    const Common::Configuration default_cfg = default_config();
-    // get gradient
-    std::vector< std::vector < std::string > > gradient_as_vectors;
-    if (cfg.has_key("gradient")) {
-      // get gradient as FieldMatrix
-      typedef typename Dune::FieldMatrix< std::string, dimRange, dimDomain > JacobianMatrixType;
-      const JacobianMatrixType gradient_as_matrix = cfg.get< JacobianMatrixType >("gradient");
-      // convert FieldMatrix to std::vector< std::vector < std::string > >
-      for (size_t rr = 0; rr < dimRange; ++rr) {
-        std::vector< std::string > gradient_expression;
-        for (size_t cc = 0; cc < dimDomain; ++cc)
-          gradient_expression.emplace_back(gradient_as_matrix[rr][cc]);
-        gradient_as_vectors.emplace_back(gradient_expression);
-      }
-    }
-    // create
-    return Common::make_unique< ThisType >(
-          cfg.get("variable",   default_cfg.get< std::string >("variable")),
-          cfg.get("expression", default_cfg.get< std::vector< std::string > >("expression")),
-          cfg.get("order",      default_cfg.get< size_t >("order")),
-          cfg.get("name",       default_cfg.get< std::string >("name")),
-          gradient_as_vectors);
-  } // ... create(...)
-
-  Expression(const std::string variable,
-             const std::string expression,
-             const size_t ord = default_config().get< size_t >("order"),
-             const std::string nm = static_id(),
-             const std::vector< std::vector< std::string > > gradient_expressions
-                = std::vector< std::vector< std::string > >())
-    : function_(new MathExpressionFunctionType(variable, expression))
-    , order_(ord)
-    , name_(nm)
-  {
-    build_gradients(variable, gradient_expressions);
-  }
-
-  Expression(const std::string variable,
-             const std::vector< std::string > expressions,
-             const size_t ord = default_config().get< size_t >("order"),
-             const std::string nm = static_id(),
-             const std::vector< std::vector< std::string > > gradient_expressions
-                = std::vector< std::vector< std::string > >())
-    : function_(new MathExpressionFunctionType(variable, expressions))
-    , order_(ord)
-    , name_(nm)
-  {
-    build_gradients(variable, gradient_expressions);
-  }
-
-  virtual std::string name() const override
-  {
-    return name_;
-  }
-
   virtual size_t order() const override
   {
     return order_;
@@ -268,61 +226,178 @@ public:
 
   virtual void evaluate(const DomainType& xx, RangeType& ret) const override
   {
-    function_->evaluate(xx, ret);
+    evaluate_helper(xx, ret, internal::ChooseVariant< dimRangeCols >());
 #ifndef NDEBUG
 # ifndef DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS
     bool failure = false;
     std::string type;
-    if (std::isnan(ret[0])) {
-      failure = true;
-      type = "NaN";
-    } else if (std::isinf(ret[0])) {
-      failure = true;
-      type = "inf";
-    } else if (std::abs(ret[0]) > (0.9 * std::numeric_limits< double >::max())) {
-      failure = true;
-      type = "an unlikely value";
+    for (size_t rr = 0; rr < dimRange; ++rr) {
+      tmp_row_ = ret[rr];
+      for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+        if (std::isnan(tmp_row_[cc])) {
+          failure = true;
+          type = "NaN";
+        } else if (std::isinf(tmp_row_[cc])) {
+          failure = true;
+          type = "inf";
+        } else if (std::abs(tmp_row_[cc]) > (0.9 * std::numeric_limits< double >::max())) {
+          failure = true;
+          type = "an unlikely value";
+        }
+        if (failure)
+          DUNE_THROW(Stuff::Exceptions::internal_error,
+                     "evaluating this function yielded " << type << "!\n"
+                     << "The variable of this function is:     " << function_->variable() << "\n"
+                     << "The expression of this functional is: " << function_->expression().at(0) << "\n"
+                     << "You tried to evaluate it with:   xx = " << xx << "\n"
+                     << "The result was:                       " << ret << "\n\n"
+                     << "You can disable this check by defining DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS\n");
+      }
     }
-    if (failure)
-      DUNE_THROW(Stuff::Exceptions::internal_error,
-                 "evaluating this function yielded " << type << "!\n"
-                 << "The variable of this function is:     " << function_->variable() << "\n"
-                 << "The expression of this functional is: " << function_->expression().at(0) << "\n"
-                 << "You tried to evaluate it with:   xx = " << xx << "\n"
-                 << "The result was:                       " << ret << "\n\n"
-                 << "You can disable this check by defining DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS\n");
 # endif // DUNE_STUFF_FUNCTIONS_EXPRESSION_DISABLE_CHECKS
 #endif // NDEBUG
   } // ... evaluate(...)
 
   virtual void jacobian(const DomainType& xx, JacobianRangeType& ret) const override
   {
-    if (gradients_.size() == 0)
+    if (gradients_.size() == 0) {
       DUNE_THROW(NotImplemented, "This function does not provide any gradients!");
-    assert(gradients_.size() == dimRange);
-    for (size_t ii = 0; ii < dimRange; ++ii) {
-      gradients_[ii]->evaluate(xx, ret[ii]);
+    } else {
+      assert(gradients_.size() == dimRangeCols);
+      jacobian_helper(xx, ret, internal::ChooseVariant< dimRangeCols >());
     }
   } // ... jacobian(...)
 
 private:
-  void build_gradients(const std::string variable,
-                       const std::vector< std::vector< std::string > >& gradient_expressions)
+  // fill the rows of the dimRange x dimRangeCols matrix (aka vector< vector< string > > expression) in a vector of
+  // length dimRange*dimRangeCols, e.g. [3 4; 1 2] becomes [3 4 1 2], in order to create function_
+  void build_function(const std::string variable,
+                      const ExpressionStringVectorType& expressions)
   {
-    assert(gradient_expressions.size() == 0 || gradient_expressions.size() >= dimRange);
-    if (gradient_expressions.size() > 0)
-      for (size_t rr = 0; rr < dimRange; ++rr) {
-        const auto& gradient_expression = gradient_expressions[rr];
-        assert(gradient_expression.size() >= dimDomain);
-        gradients_.emplace_back(new MathExpressionGradientType(variable, gradient_expression));
+    assert(expressions.size() >= dimRange);
+    std::vector< std::string > reordered_expressions;
+    for (size_t rr = 0; rr < dimRange; ++rr) {
+      assert(expressions[rr].size() >= dimRangeCols);
+      for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+        reordered_expressions.emplace_back(expressions[rr][cc]);
       }
+    }
+    function_ = std::make_shared< MathExpressionFunctionType >(variable, reordered_expressions);
+  } // ... build_function(...)
+
+  void build_gradients(const std::string variable,
+                       const GradientStringVectorType& gradient_expressions)
+  {
+    assert(gradient_expressions.size() == 0 || gradient_expressions.size() >= dimRangeCols);
+    if (gradient_expressions.size() > 0) {
+      for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+        gradients_.emplace_back(std::vector< std::shared_ptr< const MathExpressionGradientType > >());
+        assert(gradient_expressions[cc].size() >= dimRange);
+        for (size_t rr = 0; rr < dimRange; ++rr) {
+          const auto& gradient_expression = gradient_expressions[cc][rr];
+          assert(gradient_expressions[cc][rr].size() >= dimDomain);
+          gradients_[cc].emplace_back(new MathExpressionGradientType(variable, gradient_expression));
+        }
+      }
+    }
   } // ... build_gradients(...)
+
+  template< size_t rC >
+  void evaluate_helper(const DomainType& xx, RangeType& ret, internal::ChooseVariant< rC >) const
+  {
+    function_->evaluate(xx, tmp_vector_);
+    for (size_t rr = 0; rr < dimRange; ++rr) {
+      auto& retRow = ret[rr];
+      for (size_t cc = 0; cc < dimRangeCols; ++cc)
+        retRow[cc] = tmp_vector_[rr*dimRangeCols + cc];
+    }
+  } // ... evaluate_helper(...)
+
+  void evaluate_helper(const DomainType& xx, RangeType& ret, internal::ChooseVariant< 1 >) const
+  {
+    function_->evaluate(xx, ret);
+  } // ... evaluate_helper(..., ...< 1 >)
+
+  template< size_t rC >
+  void jacobian_helper(const DomainType& xx, JacobianRangeType& ret, internal::ChooseVariant< rC >) const
+  {
+    for (size_t cc = 0; cc < dimRangeCols; ++cc) {
+      assert(gradients_[cc].size() == dimRange);
+      for (size_t rr = 0; rr < dimRange; ++rr) {
+        gradients_[cc][rr]->evaluate(xx, ret[cc][rr]);
+      }
+    }
+  } // ... jacobian_helper(...)
+
+  void jacobian_helper(const DomainType& xx, JacobianRangeType& ret, internal::ChooseVariant< 1 >) const
+  {
+      assert(gradients_[0].size() == dimRange);
+      for (size_t rr = 0; rr < dimRange; ++rr) {
+        gradients_[0][rr]->evaluate(xx, ret[rr]);
+      }
+  } // ... jacobian_helper(..., ...< 1 >)
+
+  template< size_t rC >
+  static void get_expression_helper(const Common::Configuration& cfg,
+                                    ExpressionStringVectorType& expression_as_vectors,
+                                    internal::ChooseVariant< rC >)
+  {
+    typedef typename Dune::FieldMatrix< std::string, dimRange, dimRangeCols > ExpressionMatrixType;
+    const ExpressionMatrixType expression_as_matrix = cfg.get< ExpressionMatrixType >("expression");
+    // convert FieldMatrix to ExpressionStringVectorType
+    for (size_t rr = 0; rr < dimRange; ++rr) {
+      std::vector< std::string > expression_row;
+      for (size_t cc = 0; cc < dimRangeCols; ++cc)
+        expression_row.emplace_back(expression_as_matrix[rr][cc]);
+      expression_as_vectors.emplace_back(expression_row);
+    }
+  } // ... get_expression_helper(...)
+
+  static void get_expression_helper(const Common::Configuration& cfg,
+                                    ExpressionStringVectorType& expression_as_vectors,
+                                    internal::ChooseVariant< 1 >)
+  {
+    typedef typename Dune::FieldVector< std::string, dimRange > ExpressionVectorType;
+    const ExpressionVectorType expression_as_vector = cfg.get< ExpressionVectorType >("expression");
+    // convert Vector to ExpressionStringVectorType
+    for (size_t rr = 0; rr < dimRange; ++rr) {
+      std::vector< std::string > expression_row(1, expression_as_vector[rr]);
+      expression_as_vectors.emplace_back(expression_row);
+    }
+  } // ... get_expression_helper(..., ...< 1 >)
+
+  static void get_gradient(const Common::Configuration& cfg,
+                           GradientStringVectorType& gradient_as_vectors,
+                           const std::string first_gradient_key)
+  {
+    // create vector of gradient keys
+    std::vector< std::string > gradient_keys(1, first_gradient_key);
+    for (size_t cc = 1; cc < dimRangeCols; ++cc)
+      gradient_keys.emplace_back("gradient." + DSC::toString(cc));
+    // get gradient as FieldMatrix for every key
+    for (std::string key: gradient_keys) {
+      ExpressionStringVectorType gradient_as_vectors_component;
+      typedef typename Dune::FieldMatrix< std::string, dimRange, dimDomain > JacobianMatrixType;
+      const JacobianMatrixType gradient_as_matrix = cfg.get< JacobianMatrixType >(key);
+      // convert FieldMatrix to ExpressionStringVectorType
+      for (size_t rr = 0; rr < dimRange; ++rr) {
+        std::vector< std::string > gradient_expression;
+        for (size_t ii = 0; ii < dimDomain; ++ii)
+          gradient_expression.emplace_back(gradient_as_matrix[rr][ii]);
+        gradient_as_vectors_component.emplace_back(gradient_expression);
+      }
+      gradient_as_vectors.emplace_back(gradient_as_vectors_component);
+    }
+  } // ... get_gradient(...)
 
   std::shared_ptr< const MathExpressionFunctionType > function_;
   size_t order_;
   std::string name_;
-  std::vector< std::shared_ptr< const MathExpressionGradientType > > gradients_;
-}; // class Expression< ..., 1 >
+  mutable FieldVector< RangeFieldType, dimRange*dimRangeCols > tmp_vector_;
+  mutable FieldVector< RangeFieldType, dimRangeCols > tmp_row_;
+  mutable FieldVector< RangeFieldType, dimDomain > tmp_gradient_row_;
+  std::vector< std::vector< std::shared_ptr< const MathExpressionGradientType > > > gradients_;
+}; // class Expression
 
 
 } // namespace Functions

--- a/dune/stuff/functions/expression.hh
+++ b/dune/stuff/functions/expression.hh
@@ -24,14 +24,6 @@
 namespace Dune {
 namespace Stuff {
 namespace Functions {
-namespace internal {
-
-
-template< size_t rangeDimCols >
-struct ChooseVariant {};
-
-
-} // namespace internal
 
 
 template< class EntityImp, class DomainFieldImp, size_t domainDim, class RangeFieldImp, size_t rangeDim, size_t rangeDimCols = 1 >

--- a/dune/stuff/functions/flattop.hh
+++ b/dune/stuff/functions/flattop.hh
@@ -120,12 +120,12 @@ public:
     return name_;
   }
 
-  virtual size_t order() const
+  virtual size_t order() const override
   {
     return 3*dimDomain;
   }
 
-  virtual void evaluate(const DomainType& xx, RangeType& ret) const
+  virtual void evaluate(const DomainType& xx, RangeType& ret) const override
   {
     ret = value_;
     for (size_t dd = 0; dd < dimDomain; ++dd) {

--- a/dune/stuff/functions/interfaces.hh
+++ b/dune/stuff/functions/interfaces.hh
@@ -131,7 +131,7 @@ class LocalfunctionSetInterface
   template< size_t dimDomain, class RangeFieldType, size_t dimRange, size_t dimRangeCols >
   struct JacobianRangeTypeSelector
   {
-    typedef double type;
+    typedef Dune::FieldVector< Dune::FieldMatrix< RangeFieldType, dimRange, dimDomain >, dimRangeCols > type;
   };
 
   template< size_t dimDomain, class RangeFieldType, size_t dimRange >

--- a/dune/stuff/functions/interfaces.hh
+++ b/dune/stuff/functions/interfaces.hh
@@ -74,6 +74,16 @@ struct is_localizable_function;
 
 
 namespace Functions {
+namespace internal {
+
+
+// additional argument for member functions to differentiate between dimRangeCols = 1 and dimRangeCols > 1 by overloading
+template< size_t rangeDimCols >
+struct ChooseVariant {};
+
+
+} // namespace internal
+
 
 #if HAVE_DUNE_GRID
 

--- a/dune/stuff/test/functions_expression.cc
+++ b/dune/stuff/test/functions_expression.cc
@@ -35,9 +35,17 @@
     { \
       Dune::Stuff::Common::Configuration config = LocalizableFunctionType::default_config(); \
       const std::unique_ptr< const LocalizableFunctionType > function(LocalizableFunctionType::create(config)); \
-      config["expression"] = "[2*x[0] 2*x[1] 2*x[2]]"; \
-      config["gradient"] = "[2 0 0; 0 2 0; 0 0 2]"; \
+      config["expression"] = "[2*x[0] 3*x[0] 4*x[0]; 1 sin(x[0]) 0; cos(x[0]) x[0] 0]"; \
+      config["gradient"] = "[2 0 0; 0 0 0; -sin(x[0]) 0 0]"; \
+      config["gradient.1"] = "[3 0 0; cos(x[0]) 0 0; 1 0 0]"; \
+      config["gradient.2"] = "[4 0 0; 0 0 0; 0 0 0]"; \
       const std::unique_ptr< const LocalizableFunctionType > function2(LocalizableFunctionType::create(config)); \
+      const std::unique_ptr< const LocalizableFunctionType > function3( \
+                                                new LocalizableFunctionType("x", \
+                                                                            "sin(x[0])", \
+                                                                            3, \
+                                                                            LocalizableFunctionType::static_id(), \
+                                                                            {"cos(x[0])", "0", "0"})); \
     } \
   };
 // TEST_STRUCT_GENERATOR
@@ -53,32 +61,32 @@ typedef Dune::SGrid< 3, 3 >::Codim< 0 >::Entity DuneSGrid3dEntityType;
 
 // the matrix valued version is missing the create() and default_config() method
 typedef testing::Types< Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid1dEntityType, double, 1, double, 3, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid2dEntityType, double, 2, double, 3, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneSGrid3dEntityType, double, 3, double, 3, 3 >
                         > ExpressionFunctionSGridEntityTypes;
 
 TEST_STRUCT_GENERATOR(ExpressionFunction, SGridEntity)
@@ -94,32 +102,32 @@ typedef Dune::YaspGrid< 2 >::Codim< 0 >::Entity DuneYaspGrid2dEntityType;
 typedef Dune::YaspGrid< 3 >::Codim< 0 >::Entity DuneYaspGrid3dEntityType;
 
 typedef testing::Types< Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid1dEntityType, double, 1, double, 3, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid2dEntityType, double, 2, double, 3, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneYaspGrid3dEntityType, double, 3, double, 3, 3 >
                         > ExpressionFunctionYaspGridEntityTypes;
 
 TEST_STRUCT_GENERATOR(ExpressionFunction, YaspGridEntity)
@@ -129,43 +137,41 @@ TYPED_TEST(ExpressionFunctionYaspGridEntityTest, provides_required_methods) {
 }
 
 # if HAVE_ALUGRID
-#   include <dune/stuff/common/disable_warnings.hh>
-#     include <dune/grid/alugrid.hh>
-#   include <dune/stuff/common/reenable_warnings.hh>
+#   include <dune/grid/alugrid.hh>
 
 typedef Dune::ALUGrid< 2, 2, Dune::simplex, Dune::nonconforming>::Codim< 0 >::Entity  DuneAluSimplexGrid2dEntityType;
 typedef Dune::ALUGrid< 3, 3, Dune::simplex, Dune::nonconforming>::Codim< 0 >::Entity  DuneAluSimplexGrid3dEntityType;
 typedef Dune::ALUGrid< 3, 3, Dune::cube, Dune::nonconforming>::Codim< 0 >::Entity     DuneAluCubeGrid3dEntityType;
 
 typedef testing::Types< Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid2dEntityType, double, 2, double, 3, 3 >
 
                       , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluSimplexGrid3dEntityType, double, 3, double, 3, 3 >
 
                       , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 1, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 1, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 1, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 1, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 1, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 2, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 2, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 2, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 2, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 2, 3 >
                       , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 3, 1 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 3, 2 >
-//                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 3, 3 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 3, 2 >
+                      , Dune::Stuff::Functions::Expression< DuneAluCubeGrid3dEntityType, double, 3, double, 3, 3 >
                         > ExpressionFunctionAluGridEntityTypes;
 
 TEST_STRUCT_GENERATOR(ExpressionFunction, AluGridEntity)
@@ -174,7 +180,7 @@ TYPED_TEST(ExpressionFunctionAluGridEntityTest, provides_required_methods) {
   this->check();
 }
 
-# endif // HAVE_ALUGRID_SERIAL || HAVE_ALUGRID_PARALLEL
+# endif // HAVE_ALUGRID
 #endif // HAVE_DUNE_GRID
 
 


### PR DESCRIPTION
This pull request removes the specialization of Expression for dimRangeCols = 1 and makes the unspecialized variant usable for dimRangeCols > 1. 
I decided to use 
```c++
FieldVector< FieldMatrix< dimRange, dimDomain >, dimRangeCols >
```
as JacobianRangeType for dimRangeCols > 1 instead of 
```c++
FieldVector< FieldMatrix< dimRange, dimRangeCols >, dimDomain >
```
which I wanted to use first. This is more consistent with the JacobianRangeType for dimRangeCols = 1.
The "expression"-key in the config has to contain a Matrix, e.g. "[1 2; 3 4]". For dimRangeCols = 1 you can still use a vector, i.e. "[1 3]" and "[1 2; 3 4]" will both create the same Expression function for dimRangeCols = 1.
The "gradient" key is unchanged for dimRangeCols = 1, for dimRangeCols = n there has to be a key "gradient.i" for i in 1...n representing the jacobian of the i-th column. "gradient.0" can be replaced by "gradient".
I also had to adapt the jacobian() functions of Checkerboard and Constant to fix compilation errors due to the new JacobianRangeType;
