### PR TITLE
small fixes due to recent changes in float_cmp and vector

### DIFF
--- a/dune/stuff/common/float_cmp_internal.hh
+++ b/dune/stuff/common/float_cmp_internal.hh
@@ -13,7 +13,6 @@
 
 #include <dune/stuff/common/type_utils.hh>
 #include <dune/stuff/common/float_cmp_style.hh>
-//#include <dune/stuff/common/vector.hh>
 
 namespace Dune {
 namespace FloatCmp {

--- a/dune/stuff/common/float_cmp_internal.hh
+++ b/dune/stuff/common/float_cmp_internal.hh
@@ -13,7 +13,7 @@
 
 #include <dune/stuff/common/type_utils.hh>
 #include <dune/stuff/common/float_cmp_style.hh>
-#include <dune/stuff/common/vector.hh>
+//#include <dune/stuff/common/vector.hh>
 
 namespace Dune {
 namespace FloatCmp {
@@ -25,6 +25,16 @@ struct EpsilonType<std::complex<T> > {
 }
 namespace Stuff {
 namespace Common {
+
+
+// forward, include is below
+template< class VecType >
+struct VectorAbstraction;
+
+template< class VecType >
+struct is_vector;
+
+
 namespace FloatCmp {
 namespace internal {
 
@@ -252,5 +262,6 @@ struct cmp_type_check {
 } // namespace Stuff
 } // namespace Dune
 
+#include <dune/stuff/common/vector.hh>
 
 #endif // DUNE_STUFF_COMMON_FLOAT_CMP_INTERNAL_HH

--- a/dune/stuff/common/vector.hh
+++ b/dune/stuff/common/vector.hh
@@ -16,6 +16,7 @@
 #include <dune/stuff/common/exceptions.hh>
 #include <dune/stuff/common/fvector.hh>
 #include <dune/stuff/common/type_utils.hh>
+#include <dune/stuff/common/float_cmp.hh>
 
 
 namespace Dune {


### PR DESCRIPTION
Due to the deprecation warnings in vector, you have to include float_cmp. This triggered some compiler errors in float_cmp_internal, which should be cured by this pull request.

@renemilk: except from this minor issue, your recent changes for complex usage does not seem to break anything existing for me ( I didn't test excessively, though). Still, I wondered a little that you implemented cmp_gt, cmp_lt also for complex because I think that comparison of complex numbers does not make much sense mathematically. Or do you need this somewhere? 