### PR TITLE
Profiler timing change

### DIFF
--- a/dune/stuff/common/profiler.cc
+++ b/dune/stuff/common/profiler.cc
@@ -76,30 +76,6 @@ TimingData::DeltaType TimingData::delta() const
             cast(elapsed.system * scale)}};
 }
 
-void Profiler::startTiming(const std::string section_name, const size_t i)
-{
-    const std::string section = section_name + toString(i);
-    startTiming(section);
-}
-
-long  Profiler::stopTiming(const std::string section_name, const size_t i, const bool use_walltime)
-{
-    const std::string section = section_name + toString(i);
-    return stopTiming(section, use_walltime);
-}
-
-long  Profiler::getTiming(const std::string section_name, const size_t i, const bool use_walltime) const
-{
-    const std::string section = section_name + toString(i);
-    return getTiming(section, use_walltime);
-}
-
-void Profiler::resetTiming(const std::string section_name, const size_t i)
-{
-    const std::string section = section_name + toString(i);
-    return resetTiming(section);
-}
-
 void Profiler::resetTiming(const std::string section_name)
 {
     try {

--- a/dune/stuff/common/profiler.cc
+++ b/dune/stuff/common/profiler.cc
@@ -110,7 +110,7 @@ void Profiler::startTiming(const std::string section_name) {
   DSC_LIKWID_BEGIN_SECTION(section_name)
 } // StartTiming
 
-long Profiler::stopTiming(const std::string section_name, const bool /*use_walltime*/) {
+long Profiler::stopTiming(const std::string section_name) {
   DSC_LIKWID_END_SECTION(section_name)
   assert( current_run_number_ < datamaps_.size() );
   if ( known_timers_map_.find(section_name) == known_timers_map_.end() )
@@ -130,9 +130,14 @@ long Profiler::stopTiming(const std::string section_name, const bool /*use_wallt
   return delta[0];
 } // StopTiming
 
-long Profiler::getTiming(const std::string section_name, const bool /*use_walltime*/) const {
+long Profiler::getTiming(const std::string section_name) const {
+  return get_delta(section_name)[0];
+}
+
+TimingData::DeltaType Profiler::get_delta(const std::string section_name) const
+{
   assert( current_run_number_ < datamaps_.size() );
-  return getTimingIdx(section_name, current_run_number_)[0];
+  return getTimingIdx(section_name, current_run_number_);
 }
 
 TimingData::DeltaType Profiler::getTimingIdx(const std::string section_name, const size_t run_number) const {

--- a/dune/stuff/common/profiler.cc
+++ b/dune/stuff/common/profiler.cc
@@ -71,8 +71,7 @@ TimingData::DeltaType TimingData::delta() const
     const auto scale = 1.0 / double(boost::timer::nanosecond_type(1e6));
     const auto elapsed = timer_->elapsed();
     const auto cast = [=](double var) { return static_cast<typename TimingData::DeltaType::value_type>(var); };
-    return {{cast((elapsed.user + elapsed.system) * scale/ double(threadManager().current_threads())),
-            cast(elapsed.wall * scale),
+    return {{cast(elapsed.wall * scale),
             cast(elapsed.user * scale),
             cast(elapsed.system * scale)}};
 }
@@ -110,7 +109,7 @@ void Profiler::resetTiming(const std::string section_name)
         //ok, timer simply wasn't running
     }
     Datamap& current_data = datamaps_[current_run_number_];
-    current_data[section_name] = {{0, 0, 0, 0}};
+    current_data[section_name] = {{0, 0, 0}};
 }
 
 void Profiler::startTiming(const std::string section_name) {
@@ -135,7 +134,7 @@ void Profiler::startTiming(const std::string section_name) {
   DSC_LIKWID_BEGIN_SECTION(section_name)
 } // StartTiming
 
-long Profiler::stopTiming(const std::string section_name, const bool use_walltime) {
+long Profiler::stopTiming(const std::string section_name, const bool /*use_walltime*/) {
   DSC_LIKWID_END_SECTION(section_name)
   assert( current_run_number_ < datamaps_.size() );
   if ( known_timers_map_.find(section_name) == known_timers_map_.end() )
@@ -152,15 +151,15 @@ long Profiler::stopTiming(const std::string section_name, const bool use_walltim
     for(auto i : valueRange(delta.size()))
       current_data[section_name][i] += delta[i];
   }
-  return use_walltime ? delta[1] : delta[0];
+  return delta[0];
 } // StopTiming
 
-long Profiler::getTiming(const std::string section_name, const bool use_walltime) const {
+long Profiler::getTiming(const std::string section_name, const bool /*use_walltime*/) const {
   assert( current_run_number_ < datamaps_.size() );
-  return getTimingIdx(section_name, current_run_number_, use_walltime);
+  return getTimingIdx(section_name, current_run_number_)[0];
 }
 
-long Profiler::getTimingIdx(const std::string section_name, const size_t run_number, const bool use_walltime) const {
+TimingData::DeltaType Profiler::getTimingIdx(const std::string section_name, const size_t run_number) const {
   assert( run_number < datamaps_.size() );
   const Datamap& data = datamaps_[run_number];
   Datamap::const_iterator section = data.find(section_name);
@@ -170,9 +169,9 @@ long Profiler::getTimingIdx(const std::string section_name, const size_t run_num
     const auto& timer_it = known_timers_map_.find(section_name);
     if (timer_it == known_timers_map_.end())
       DUNE_THROW(Dune::InvalidStateException, "no timer found: " + section_name);
-    return use_walltime ? timer_it->second.second->delta()[1] : timer_it->second.second->delta()[0];
+    return timer_it->second.second->delta();
   }
-  return use_walltime ? section->second[1] : section->second[0];
+  return section->second;
 } // GetTiming
 
 

--- a/dune/stuff/common/profiler.hh
+++ b/dune/stuff/common/profiler.hh
@@ -48,7 +48,7 @@ public:
   void stop();
 
   typedef boost::timer::nanosecond_type TimeType;
-  typedef std::array<TimeType, 4> DeltaType;
+  typedef std::array<TimeType, 3> DeltaType;
 
   /** \return time elapsed since object construction in milliseconds
    *  \note since typical resolutions for user+system time are 10-15ms the nanosecond results are scaled accordingly
@@ -93,20 +93,20 @@ private:
   //! appends int to section name
   long getTiming(const std::string section_name, const size_t i, const bool use_walltime ) const;
   //! get runtime of section in run run_number in milliseconds
-  long getTimingIdx(const std::string section_name, const size_t run_number, const bool use_walltime) const;
+  TimingData::DeltaType getTimingIdx(const std::string section_name, const size_t run_number) const;
 
 public:
   //! set this to begin a named section
   void startTiming(const std::string section_name);
 
   //! stop named section's counter
-  long stopTiming(const std::string section_name, const bool use_walltime = true);
+  long stopTiming(const std::string section_name, const bool /*use_walltime*/ = true);
 
   //! set elapsed time back to 0 for section_name
   void resetTiming(const std::string section_name);
 
   //! get runtime of section in current run in milliseconds
-  long getTiming(const std::string section_name, const bool use_walltime = true) const;
+  long getTiming(const std::string section_name, const bool /*use_walltime*/ = true) const;
 
   /** output to currently pre-defined (csv) file, does not output individual run results, but average over all recorded
    * results

--- a/dune/stuff/common/profiler.hh
+++ b/dune/stuff/common/profiler.hh
@@ -81,17 +81,6 @@ private:
   typedef std::vector< Datamap >
     DatamapVector;
 
-  //! appends int to section name
-  long stopTiming(const std::string section_name, const size_t i, const bool use_walltime);
-
-  //! appends int to section name
-  void startTiming(const std::string section_name, const size_t i);
-
-  //! appends int to section name
-  void resetTiming(const std::string section_name, const size_t i);
-
-  //! appends int to section name
-  long getTiming(const std::string section_name, const size_t i, const bool use_walltime ) const;
   //! get runtime of section in run run_number in milliseconds
   TimingData::DeltaType getTimingIdx(const std::string section_name, const size_t run_number) const;
 

--- a/dune/stuff/common/profiler.hh
+++ b/dune/stuff/common/profiler.hh
@@ -100,13 +100,13 @@ public:
   void startTiming(const std::string section_name);
 
   //! stop named section's counter
-  long stopTiming(const std::string section_name, const bool use_walltime = false);
+  long stopTiming(const std::string section_name, const bool use_walltime = true);
 
   //! set elapsed time back to 0 for section_name
   void resetTiming(const std::string section_name);
 
   //! get runtime of section in current run in milliseconds
-  long getTiming(const std::string section_name, const bool use_walltime = false) const;
+  long getTiming(const std::string section_name, const bool use_walltime = true) const;
 
   /** output to currently pre-defined (csv) file, does not output individual run results, but average over all recorded
    * results

--- a/dune/stuff/common/profiler.hh
+++ b/dune/stuff/common/profiler.hh
@@ -89,13 +89,14 @@ public:
   void startTiming(const std::string section_name);
 
   //! stop named section's counter
-  long stopTiming(const std::string section_name, const bool /*use_walltime*/ = true);
+  long stopTiming(const std::string section_name);
 
   //! set elapsed time back to 0 for section_name
   void resetTiming(const std::string section_name);
 
   //! get runtime of section in current run in milliseconds
-  long getTiming(const std::string section_name, const bool /*use_walltime*/ = true) const;
+  long getTiming(const std::string section_name) const;
+  TimingData::DeltaType get_delta(const std::string section_name) const;
 
   /** output to currently pre-defined (csv) file, does not output individual run results, but average over all recorded
    * results


### PR DESCRIPTION
removes use_walltime from Profiler interface, returns "real" walltime instead of mixed number. This is relevant to your interests, @tobiasleibner  